### PR TITLE
Fix incorrect phase directory naming in agent-executor

### DIFF
--- a/src/phases/core/agent-executor.ts
+++ b/src/phases/core/agent-executor.ts
@@ -144,7 +144,7 @@ export class AgentExecutor {
     prompt: string,
     options?: { maxTurns?: number; verbose?: boolean; logDir?: string },
   ): Promise<{ messages: string[]; authFailed: boolean }> {
-    const logDir = options?.logDir ?? path.join(this.metadata.workflowDir, `0${this.getPhaseNumber(this.phaseName)}_${this.phaseName}`, 'execute');
+    const logDir = options?.logDir ?? path.join(this.metadata.workflowDir, `${this.getPhaseNumber(this.phaseName)}_${this.phaseName}`, 'execute');
     const promptFile = path.join(logDir, 'prompt.txt');
     const rawLogFile = path.join(logDir, 'agent_log_raw.txt');
     const agentLogFile = path.join(logDir, 'agent_log.md');


### PR DESCRIPTION
- Remove extra '0' prefix in logDir path construction (line 147)
- Was: `0${this.getPhaseNumber(this.phaseName)}` → resulted in '000_planning'
- Now: `${this.getPhaseNumber(this.phaseName)}` → correctly produces '00_planning'

This fixes the error where logs were saved to 000_planning but the code expected to read from 00_planning, causing "planning.md not found" errors.

Root cause: getPhaseNumber() already returns '00' for planning phase, adding '0' prefix created '000' instead of expected '00'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)