### PR TITLE
Increase maxTurns for complex phases to prevent timeout

### DIFF
--- a/src/phases/documentation.ts
+++ b/src/phases/documentation.ts
@@ -55,7 +55,7 @@ export class DocumentationPhase extends BasePhase {
       .replace('{test_implementation_context}', testImplementationContext)
       .replace('{issue_number}', String(issueNumber));
 
-    await this.executeWithAgent(executePrompt, { maxTurns: 50 });
+    await this.executeWithAgent(executePrompt, { maxTurns: 70 });
 
     const documentationFile = path.join(this.outputDir, 'documentation-update-log.md');
     if (!fs.existsSync(documentationFile)) {
@@ -130,7 +130,7 @@ export class DocumentationPhase extends BasePhase {
       reviewFeedback,
     );
 
-    await this.executeWithAgent(revisePrompt, { maxTurns: 50, logDir: this.reviseDir });
+    await this.executeWithAgent(revisePrompt, { maxTurns: 70, logDir: this.reviseDir });
 
     if (!fs.existsSync(documentationFile)) {
       return {

--- a/src/phases/implementation.ts
+++ b/src/phases/implementation.ts
@@ -46,7 +46,7 @@ export class ImplementationPhase extends BasePhase {
       .replace('{implementation_strategy}', implementationStrategy)
       .replace('{issue_number}', String(issueNumber));
 
-    await this.executeWithAgent(executePrompt, { maxTurns: 50 });
+    await this.executeWithAgent(executePrompt, { maxTurns: 100 });
 
     const implementationFile = path.join(this.outputDir, 'implementation.md');
     if (!fs.existsSync(implementationFile)) {
@@ -196,7 +196,7 @@ export class ImplementationPhase extends BasePhase {
       .replace('{review_feedback}', reviewFeedback)
       .replace('{issue_number}', String(issueNumber));
 
-    await this.executeWithAgent(revisePrompt, { maxTurns: 50, logDir: this.reviseDir });
+    await this.executeWithAgent(revisePrompt, { maxTurns: 100, logDir: this.reviseDir });
 
     if (!fs.existsSync(implementationFile)) {
       return {

--- a/src/phases/test-implementation.ts
+++ b/src/phases/test-implementation.ts
@@ -57,7 +57,7 @@ export class TestImplementationPhase extends BasePhase {
       .replace('{test_code_strategy}', testCodeStrategy)
       .replace('{issue_number}', String(issueNumber));
 
-    await this.executeWithAgent(executePrompt, { maxTurns: 40 });
+    await this.executeWithAgent(executePrompt, { maxTurns: 80 });
 
     const testImplementationFile = path.join(this.outputDir, 'test-implementation.md');
     if (!fs.existsSync(testImplementationFile)) {
@@ -229,7 +229,7 @@ export class TestImplementationPhase extends BasePhase {
       .replace('{review_feedback}', reviewFeedback)
       .replace('{issue_number}', String(issueNumber));
 
-    await this.executeWithAgent(revisePrompt, { maxTurns: 50, logDir: this.reviseDir });
+    await this.executeWithAgent(revisePrompt, { maxTurns: 80, logDir: this.reviseDir });
 
     if (!fs.existsSync(testImplementationFile)) {
       return {

--- a/src/phases/test-scenario.ts
+++ b/src/phases/test-scenario.ts
@@ -53,7 +53,7 @@ export class TestScenarioPhase extends BasePhase {
       .replace('{issue_info}', this.formatIssueInfo(issueInfo))
       .replace('{issue_number}', String(issueInfo.number));
 
-    await this.executeWithAgent(executePrompt, { maxTurns: 40 });
+    await this.executeWithAgent(executePrompt, { maxTurns: 60 });
 
     const scenarioFile = path.join(this.outputDir, 'test-scenario.md');
     if (!fs.existsSync(scenarioFile)) {
@@ -197,7 +197,7 @@ export class TestScenarioPhase extends BasePhase {
       .replace('{review_feedback}', reviewFeedback)
       .replace('{issue_number}', String(issueInfo.number));
 
-    await this.executeWithAgent(revisePrompt, { maxTurns: 40, logDir: this.reviseDir });
+    await this.executeWithAgent(revisePrompt, { maxTurns: 60, logDir: this.reviseDir });
 
     if (!fs.existsSync(scenarioFile)) {
       return {

--- a/src/phases/testing.ts
+++ b/src/phases/testing.ts
@@ -45,7 +45,7 @@ export class TestingPhase extends BasePhase {
       .replace('{test_scenario_context}', scenarioContext)
       .replace('{issue_number}', String(issueNumber));
 
-    await this.executeWithAgent(executePrompt, { maxTurns: 50 });
+    await this.executeWithAgent(executePrompt, { maxTurns: 80 });
 
     if (!fs.existsSync(testResultFile)) {
       return {
@@ -214,7 +214,7 @@ export class TestingPhase extends BasePhase {
     const oldMtime = fs.statSync(testResultFile).mtimeMs;
     const oldSize = fs.statSync(testResultFile).size;
 
-    await this.executeWithAgent(revisePrompt, { maxTurns: 50, logDir: this.reviseDir });
+    await this.executeWithAgent(revisePrompt, { maxTurns: 80, logDir: this.reviseDir });
 
     if (!fs.existsSync(testResultFile)) {
       return {


### PR DESCRIPTION
- Implementation: 50 → 100 (execute & revise)
- TestImplementation: 40 → 80 (execute), 50 → 80 (revise)
- Testing: 50 → 80 (execute & revise)
- Documentation: 50 → 70 (execute & revise)
- TestScenario: 40 → 60 (execute & revise)

Addresses issue where implementation phase hits error_max_turns with turn limit of 50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)