### PR TITLE
Add AWS CLI, Pulumi CLI, jq, and curl to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,20 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         git \
         ca-certificates \
+        curl \
+        jq \
+        unzip \
     && rm -rf /var/lib/apt/lists/*
+
+# Install AWS CLI v2
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -rf aws awscliv2.zip
+
+# Install Pulumi CLI
+RUN curl -fsSL https://get.pulumi.com | bash && \
+    mv /root/.pulumi/bin/* /usr/local/bin/
 
 # Configure Git defaults (used by init/execute commands)
 RUN git config --global --add safe.directory '*' && \


### PR DESCRIPTION
- Install curl and jq via apt-get
- Install AWS CLI v2 using official installer
- Install Pulumi CLI using official installation script
- Add unzip package (required for AWS CLI installation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)