### PR TITLE
Fix Jenkins ISSUE_URL validation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -166,6 +166,10 @@ pipeline {
                         error("ISSUE_URL は GitHub Issue URLである必要があります: ${params.ISSUE_URL}")
                     }
 
+                    if (!params.ISSUE_URL.contains('/issues/')) {
+                        error("ISSUE_URL は GitHub Issue URL (/issues/) である必要があります: ${params.ISSUE_URL}")
+                    }
+
                     // Issue番号とリポジトリ情報抽出
                     def urlParts = params.ISSUE_URL.split('/')
                     env.ISSUE_NUMBER = urlParts[-1]


### PR DESCRIPTION
## Summary
- ensure the Jenkins pipeline rejects ISSUE_URL values that do not point to a GitHub issues page
- add an explicit check for the `/issues/` path segment during parameter validation

## Testing
- not run (Jenkinsfile change only)


------
https://chatgpt.com/codex/tasks/task_e_690208823db483209b8a6737f058e74b