### PR TITLE
fix(rollback): Use PHASE_ORDER for consistent phase ordering

### DIFF
--- a/src/core/metadata-manager.ts
+++ b/src/core/metadata-manager.ts
@@ -11,6 +11,23 @@ import {
 } from '../types.js';
 import { formatTimestampForFilename, backupMetadataFile, removeWorkflowDirectory } from './helpers/metadata-io.js';
 
+/**
+ * フェーズの順序を定義
+ * Object.keys() の順序は保証されないため、明示的な配列で順序を管理
+ */
+const PHASE_ORDER: PhaseName[] = [
+  'planning',
+  'requirements',
+  'design',
+  'test_scenario',
+  'implementation',
+  'test_implementation',
+  'testing',
+  'documentation',
+  'report',
+  'evaluation',
+];
+
 export class MetadataManager {
   public readonly metadataPath: string;
   public readonly workflowDir: string;
@@ -323,16 +340,16 @@ export class MetadataManager {
    * @returns リセットされたフェーズ名の配列
    */
   public resetSubsequentPhases(fromPhase: PhaseName): PhaseName[] {
-    const phases = Object.keys(this.state.data.phases) as PhaseName[];
-    const startIndex = phases.indexOf(fromPhase);
+    // PHASE_ORDER を使用して順序を保証（Object.keys の順序は保証されない）
+    const startIndex = PHASE_ORDER.indexOf(fromPhase);
 
     if (startIndex === -1) {
-      logger.warn(`Phase ${fromPhase} not found in metadata`);
+      logger.warn(`Phase ${fromPhase} not found in PHASE_ORDER`);
       return [];
     }
 
     // 指定フェーズより後のフェーズをリセット
-    const subsequentPhases = phases.slice(startIndex + 1);
+    const subsequentPhases = PHASE_ORDER.slice(startIndex + 1);
 
     for (const phase of subsequentPhases) {
       const phaseData = this.state.data.phases[phase];


### PR DESCRIPTION
- Add PHASE_ORDER constant to metadata-manager.ts
- Fix resetSubsequentPhases() to use PHASE_ORDER instead of Object.keys()
- Object.keys() order is not guaranteed, causing rollback to fail when subsequent phases are not properly reset

This fixes the issue where rollback to implementation phase still resumed from test_implementation instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)