### PR TITLE
fix(cleanup): Include 09_evaluation in cleanupWorkflowLogs

### DIFF
--- a/src/phases/cleanup/artifact-cleaner.ts
+++ b/src/phases/cleanup/artifact-cleaner.ts
@@ -101,7 +101,7 @@ export class ArtifactCleaner {
   /**
    * ワークフローログをクリーンアップ（Issue #2）
    *
-   * Report Phase 完了後に実行され、phases 00-08 の execute/review/revise ディレクトリを削除します。
+   * Report Phase 完了後に実行され、phases 00-09 の execute/review/revise ディレクトリを削除します。
    * metadata.json と output/*.md は保持されます。
    *
    * @example
@@ -116,7 +116,7 @@ export class ArtifactCleaner {
     logger.info('Cleaning up workflow execution logs...');
 
     try {
-      // phases 00-08 のディレクトリをループ
+      // phases 00-09 のディレクトリをループ
       const phaseDirs = [
         '00_planning',
         '01_requirements',
@@ -127,6 +127,7 @@ export class ArtifactCleaner {
         '06_testing',
         '07_documentation',
         '08_report',
+        '09_evaluation',
       ];
 
       for (const phaseDir of phaseDirs) {

--- a/tests/unit/phases/cleanup/artifact-cleaner.test.ts
+++ b/tests/unit/phases/cleanup/artifact-cleaner.test.ts
@@ -50,8 +50,8 @@ describe('ArtifactCleaner - cleanupWorkflowLogs() 正常系', () => {
     await fs.remove(TEST_DIR);
   });
 
-  test('UC-AC-01: cleanupWorkflowLogs() - phases 00-08 の execute/review/revise が削除され、metadata.json と output/*.md が保持される', async () => {
-    // Given: phases 00-08 のディレクトリが存在する
+  test('UC-AC-01: cleanupWorkflowLogs() - phases 00-09 の execute/review/revise が削除され、metadata.json と output/*.md が保持される', async () => {
+    // Given: phases 00-09 のディレクトリが存在する
     const phaseDirs = [
       '00_planning',
       '01_requirements',
@@ -62,6 +62,7 @@ describe('ArtifactCleaner - cleanupWorkflowLogs() 正常系', () => {
       '06_testing',
       '07_documentation',
       '08_report',
+      '09_evaluation',
     ];
 
     for (const phaseDir of phaseDirs) {


### PR DESCRIPTION
## Summary

- `cleanupWorkflowLogs()` が `09_evaluation` の `execute/review/revise` ディレクトリを削除するよう修正
- `phaseDirs` 配列に `'09_evaluation'` を追加
- 関連するJSDocコメントとテストを `00-08` から `00-09` に更新

## Test plan

- [ ] `all_phases` でワークフローを実行し、完了後に `09_evaluation/execute` と `09_evaluation/review` が削除されることを確認

Fixes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)