### PR TITLE
fix(jenkins): Remove redundant env vars from Docker args

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,7 +78,9 @@ pipeline {
             label 'ec2-fleet'
             dir '.'
             filename 'Dockerfile'
-            args '-v ${WORKSPACE}:/workspace -w /workspace -e CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=1 -e CODEX_API_KEY=${CODEX_API_KEY} -e OPENAI_API_KEY=${OPENAI_API_KEY} -e CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN} -e CLAUDE_CODE_API_KEY=${CLAUDE_CODE_API_KEY} -e ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY} -e GITHUB_TOKEN=${GITHUB_TOKEN} -e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} -e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} -e AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}'
+            // 注意: シングルクォートではGroovy変数が展開されないため、ダブルクォートを使用
+            // 環境変数は environment ブロックで params から設定済み
+            args "-v \${WORKSPACE}:/workspace -w /workspace -e CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=1"
         }
     }
 


### PR DESCRIPTION
The environment variables set in the `environment` block are automatically passed to the Docker container by Jenkins Pipeline. Specifying them again in `args` with single quotes caused them to be passed as literal strings (e.g., "${CODEX_API_KEY}" instead of the actual value).

This was causing:
- CODEX_API_KEY to be detected as 16 characters (the literal string)
- CLAUDE_CODE_OAUTH_TOKEN to fail with "Invalid API key"

Fixes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)