### PR TITLE
feat: AI Workflow Jenkins Job定義をinfrastructure-as-codeから移行

### DIFF
--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -1,0 +1,94 @@
+# AI Workflow Jenkins Jobs
+
+このディレクトリには、AI Workflow関連のJenkins Job定義が含まれています。
+
+> **Note**: これらのファイルは `infrastructure-as-code` リポジトリから移行されました（Issue #230）
+
+## ディレクトリ構造
+
+```
+jenkins/
+└── jobs/
+    ├── pipeline/
+    │   └── _seed/
+    │       └── ai-workflow-job-creator/
+    │           ├── Jenkinsfile          # シードジョブ定義
+    │           ├── folder-config.yaml   # フォルダ構成定義
+    │           └── job-config.yaml      # ジョブ設定
+    └── dsl/
+        ├── folders.groovy               # フォルダ作成DSL
+        └── ai-workflow/
+            ├── ai_workflow_all_phases_job.groovy
+            ├── ai_workflow_preset_job.groovy
+            ├── ai_workflow_single_phase_job.groovy
+            ├── ai_workflow_rollback_job.groovy
+            ├── ai_workflow_auto_issue_job.groovy
+            └── TEST_PLAN.md
+```
+
+## 利用可能なジョブ
+
+### ジョブ一覧
+
+| ジョブ名 | 説明 | パラメータ数 |
+|---------|------|-------------|
+| **all_phases** | 全フェーズ一括実行（planning → evaluation） | 20 |
+| **preset** | プリセット実行（quick-fix, implementation等） | 21 |
+| **single_phase** | 単一フェーズ実行（デバッグ用） | 19 |
+| **rollback** | フェーズ差し戻し実行 | 18 |
+| **auto_issue** | 自動Issue作成 | 14 |
+
+### フォルダ構成
+
+ジョブは以下のフォルダ構成で配置されます：
+
+```
+AI_Workflow/
+├── develop/           # developブランチ用（最新バージョン）
+│   ├── all_phases
+│   ├── preset
+│   ├── single_phase
+│   ├── rollback
+│   └── auto_issue
+├── stable-1/          # mainブランチ用（安定バージョン）
+│   └── ...
+├── stable-2/
+├── ...
+└── stable-9/
+```
+
+- **develop**: ai-workflow-agentのdevelopブランチを使用（新機能テスト用）
+- **stable-1〜9**: ai-workflow-agentのmainブランチを使用（本番環境用、並行実行可能）
+
+## セットアップ
+
+### 1. シードジョブの登録
+
+Jenkinsに以下のパイプラインジョブを作成してください：
+
+- **ジョブ名**: `Admin_Jobs/ai-workflow-job-creator`
+- **Pipeline script from SCM**:
+  - SCM: Git
+  - Repository URL: `https://github.com/tielec/ai-workflow-agent.git`
+  - Branch: `*/main`
+  - Script Path: `jenkins/jobs/pipeline/_seed/ai-workflow-job-creator/Jenkinsfile`
+
+### 2. シードジョブの実行
+
+作成したシードジョブを実行すると、以下が自動生成されます：
+
+- AI_Workflowフォルダ構造
+- 各実行モード用のジョブ（5種類 × 10フォルダ = 50ジョブ）
+
+## 詳細ドキュメント
+
+各ジョブの詳細な使い方については、以下を参照してください：
+
+- [AI Workflow README](../README.md) - ワークフロー全体の説明
+- [ARCHITECTURE.md](../ARCHITECTURE.md) - アーキテクチャ詳細
+- [TEST_PLAN.md](jobs/dsl/ai-workflow/TEST_PLAN.md) - テスト計画
+
+## 関連Issue
+
+- 移行元Issue: https://github.com/tielec/infrastructure-as-code/issues/481
+- 移行先Issue: https://github.com/tielec/ai-workflow-agent/issues/230

--- a/jenkins/jobs/dsl/ai-workflow/TEST_PLAN.md
+++ b/jenkins/jobs/dsl/ai-workflow/TEST_PLAN.md
@@ -1,0 +1,580 @@
+# AI Workflow Jobs - Test Plan
+
+**Issue**: #453
+**Test Strategy**: INTEGRATION_ONLY (Jenkins環境での統合テストのみ)
+**Test Execution**: Manual testing in Jenkins environment
+**Last Updated**: 2025-01-17
+
+---
+
+## テスト概要
+
+このテストプランは、AI Workflow Orchestratorジョブを実行モードごとに分割したジョブ（5つ）の統合テストを定義します。
+
+### テスト対象ジョブ
+1. `AI_Workflow/{repository-name}/all_phases` - 全フェーズ一括実行
+2. `AI_Workflow/{repository-name}/preset` - プリセット実行
+3. `AI_Workflow/{repository-name}/single_phase` - 単一フェーズ実行
+4. `AI_Workflow/{repository-name}/rollback` - フェーズ差し戻し実行
+5. `AI_Workflow/{repository-name}/auto_issue` - 自動Issue作成
+
+### テスト環境
+- **Jenkins Version**: 2.426.1以上
+- **Required Plugins**: Job DSL Plugin, Pipeline Plugin, Git Plugin, Credentials Plugin
+- **Test Repository**: infrastructure-as-code, ai-workflow-agent
+- **Execution Mode**: Manual testing with DRY_RUN=true
+
+---
+
+## 事前準備チェックリスト
+
+実施日: ___________
+実施者: ___________
+
+- [ ] Jenkins環境が正常に動作している
+- [ ] 5つのJob DSLファイルが`jenkins/jobs/dsl/ai-workflow/`に配置されている
+  - [ ] `ai_workflow_all_phases_job.groovy`
+  - [ ] `ai_workflow_preset_job.groovy`
+  - [ ] `ai_workflow_single_phase_job.groovy`
+  - [ ] `ai_workflow_rollback_job.groovy`
+  - [ ] `ai_workflow_auto_issue_job.groovy`
+- [ ] `job-config.yaml`に5つの新しいジョブ定義が追加されている
+- [ ] `folder-config.yaml`に動的フォルダルールが追加されている
+- [ ] `jenkinsManagedRepositories`に最低1つのリポジトリが登録されている
+- [ ] GitHub Token（`github-token`）が設定されている
+
+---
+
+## Test Suite 1: シードジョブ実行テスト
+
+### TC-001: シードジョブによるジョブ生成
+
+**目的**: シードジョブを実行し、5つの新しいジョブが正しく生成されることを検証
+
+**手順**:
+1. Jenkinsにログイン
+2. `Admin_Jobs/job-creator`ジョブに移動
+3. 「Build Now」をクリックしてシードジョブを実行
+4. ビルドログを確認
+
+**期待結果**:
+- [ ] シードジョブが成功（SUCCESS）で完了する
+- [ ] ビルドログに「ERROR」「FAILED」の文字列が含まれない
+- [ ] ビルド時間が5分以内である
+
+**実行日**: ___________
+**結果**: ✅ PASS / ❌ FAIL
+**備考**: ___________________________________________
+
+---
+
+### TC-002: リポジトリ別フォルダ構造の検証
+
+**目的**: 複数のリポジトリに対して、それぞれ独立したフォルダとジョブが生成されることを検証
+
+**手順**:
+1. Jenkins Top画面に戻る
+2. `AI_Workflow`フォルダを開く
+3. 各リポジトリ名のサブフォルダが存在することを確認
+4. 各サブフォルダを開き、5つのジョブが存在することを確認
+
+**期待結果**:
+- [ ] `AI_Workflow/infrastructure-as-code/`フォルダが存在する
+- [ ] `AI_Workflow/ai-workflow-agent/`フォルダが存在する（登録されている場合）
+- [ ] 各リポジトリフォルダに以下のジョブが存在する:
+  - [ ] `all_phases` (displayName: "All Phases Execution")
+  - [ ] `preset` (displayName: "Preset Execution")
+  - [ ] `single_phase` (displayName: "Single Phase Execution")
+  - [ ] `rollback` (displayName: "Rollback Execution")
+  - [ ] `auto_issue` (displayName: "Auto Issue Creation")
+
+**実行日**: ___________
+**結果**: ✅ PASS / ❌ FAIL
+**備考**: ___________________________________________
+
+---
+
+## Test Suite 2: パラメータ定義テスト
+
+### TC-003: all_phasesジョブのパラメータ検証
+
+**目的**: all_phasesジョブのパラメータが要件通りに定義されていることを検証
+
+**手順**:
+1. `AI_Workflow/infrastructure-as-code/all_phases`ジョブを開く
+2. 「Build with Parameters」をクリック
+3. パラメータ一覧を確認
+
+**期待結果** (パラメータ数: **14個**):
+
+| パラメータ名 | 表示 | 型 | デフォルト値 |
+|------------|------|-----|------------|
+| ISSUE_URL | ✅ | String | (空文字) |
+| BRANCH_NAME | ✅ | String | (空文字) |
+| AGENT_MODE | ✅ | Choice | auto |
+| DRY_RUN | ✅ | Boolean | false |
+| SKIP_REVIEW | ✅ | Boolean | false |
+| FORCE_RESET | ✅ | Boolean | false |
+| MAX_RETRIES | ✅ | Choice | 3 |
+| CLEANUP_ON_COMPLETE_FORCE | ✅ | Boolean | false |
+| GIT_COMMIT_USER_NAME | ✅ | String | AI Workflow Bot |
+| GIT_COMMIT_USER_EMAIL | ✅ | String | ai-workflow@example.com |
+| AWS_ACCESS_KEY_ID | ✅ | String | (空文字) |
+| AWS_SECRET_ACCESS_KEY | ✅ | NonStoredPassword | - |
+| AWS_SESSION_TOKEN | ✅ | NonStoredPassword | - |
+| COST_LIMIT_USD | ✅ | String | 5.0 |
+| LOG_LEVEL | ✅ | Choice | INFO |
+
+**表示されないパラメータ**:
+- [ ] EXECUTION_MODE (内部的に固定値)
+- [ ] PRESET
+- [ ] START_PHASE
+- [ ] ROLLBACK_*
+- [ ] AUTO_ISSUE_*
+- [ ] GITHUB_REPOSITORY
+
+**実行日**: ___________
+**結果**: ✅ PASS / ❌ FAIL
+**備考**: ___________________________________________
+
+---
+
+### TC-004: presetジョブのパラメータ検証
+
+**目的**: presetジョブのパラメータが要件通りに定義されていることを検証
+
+**手順**:
+1. `AI_Workflow/infrastructure-as-code/preset`ジョブを開く
+2. 「Build with Parameters」をクリック
+3. パラメータ一覧を確認
+
+**期待結果** (パラメータ数: **15個**):
+- [ ] TC-003のall_phases用14個のパラメータ + PRESET
+- [ ] **PRESETパラメータ**が表示される（Choiceタイプ）
+- [ ] PRESETの選択肢:
+  - [ ] quick-fix
+  - [ ] implementation
+  - [ ] testing
+  - [ ] review-requirements
+  - [ ] review-design
+  - [ ] review-test-scenario
+  - [ ] finalize
+- [ ] START_PHASE、ROLLBACK_*、AUTO_ISSUE_*が表示されない
+
+**実行日**: ___________
+**結果**: ✅ PASS / ❌ FAIL
+**備考**: ___________________________________________
+
+---
+
+### TC-005: single_phaseジョブのパラメータ検証
+
+**目的**: single_phaseジョブのパラメータが要件通りに定義されていることを検証
+
+**手順**:
+1. `AI_Workflow/infrastructure-as-code/single_phase`ジョブを開く
+2. 「Build with Parameters」をクリック
+3. パラメータ一覧を確認
+
+**期待結果** (パラメータ数: **13個**):
+- [ ] **START_PHASEパラメータ**が表示される（Choiceタイプ）
+- [ ] START_PHASEの選択肢:
+  - [ ] planning
+  - [ ] requirements
+  - [ ] design
+  - [ ] test_scenario
+  - [ ] implementation
+  - [ ] test_implementation
+  - [ ] testing
+  - [ ] documentation
+  - [ ] report
+  - [ ] evaluation
+- [ ] FORCE_RESETが表示されない
+- [ ] CLEANUP_ON_COMPLETE_FORCEが表示されない
+- [ ] PRESET、ROLLBACK_*、AUTO_ISSUE_*が表示されない
+
+**実行日**: ___________
+**結果**: ✅ PASS / ❌ FAIL
+**備考**: ___________________________________________
+
+---
+
+### TC-006: rollbackジョブのパラメータ検証
+
+**目的**: rollbackジョブのパラメータが要件通りに定義されていることを検証
+
+**手順**:
+1. `AI_Workflow/infrastructure-as-code/rollback`ジョブを開く
+2. 「Build with Parameters」をクリック
+3. パラメータ一覧を確認
+
+**期待結果** (パラメータ数: **12個**):
+- [ ] **ROLLBACK_TO_PHASEパラメータ**が表示される（Choiceタイプ）
+- [ ] ROLLBACK_TO_PHASEの選択肢（evaluationは含まれない）:
+  - [ ] implementation
+  - [ ] planning
+  - [ ] requirements
+  - [ ] design
+  - [ ] test_scenario
+  - [ ] test_implementation
+  - [ ] testing
+  - [ ] documentation
+  - [ ] report
+- [ ] **ROLLBACK_TO_STEPパラメータ**が表示される（Choiceタイプ）
+  - 選択肢: revise, execute, review
+- [ ] **ROLLBACK_REASONパラメータ**が表示される（Textタイプ）
+- [ ] **ROLLBACK_REASON_FILEパラメータ**が表示される（Stringタイプ）
+- [ ] 以下が表示されない: PRESET、START_PHASE、AUTO_ISSUE_*、SKIP_REVIEW、FORCE_RESET、MAX_RETRIES、CLEANUP_ON_COMPLETE_FORCE
+
+**実行日**: ___________
+**結果**: ✅ PASS / ❌ FAIL
+**備考**: ___________________________________________
+
+---
+
+### TC-007: auto_issueジョブのパラメータ検証
+
+**目的**: auto_issueジョブのパラメータが要件通りに定義されていることを検証
+
+**手順**:
+1. `AI_Workflow/infrastructure-as-code/auto_issue`ジョブを開く
+2. 「Build with Parameters」をクリック
+3. パラメータ一覧を確認
+
+**期待結果** (パラメータ数: **8個**):
+- [ ] **GITHUB_REPOSITORYパラメータ**が表示される（Stringタイプ）
+- [ ] **AUTO_ISSUE_CATEGORYパラメータ**が表示される（Choiceタイプ）
+  - 選択肢: bug, refactor, enhancement, all
+- [ ] **AUTO_ISSUE_LIMITパラメータ**が表示される（Stringタイプ、デフォルト: 5）
+- [ ] **AUTO_ISSUE_SIMILARITY_THRESHOLDパラメータ**が表示される（Stringタイプ、デフォルト: 0.8）
+- [ ] AGENT_MODE、DRY_RUN、COST_LIMIT_USD、LOG_LEVELが表示される
+- [ ] 以下が表示されない: ISSUE_URL、BRANCH_NAME、PRESET、START_PHASE、ROLLBACK_*、SKIP_REVIEW、FORCE_RESET、MAX_RETRIES、CLEANUP_ON_COMPLETE_FORCE、GIT_COMMIT_*、AWS_*
+
+**実行日**: ___________
+**結果**: ✅ PASS / ❌ FAIL
+**備考**: ___________________________________________
+
+---
+
+## Test Suite 3: EXECUTION_MODE設定テスト
+
+### TC-008: all_phasesジョブのEXECUTION_MODE検証
+
+**目的**: all_phasesジョブがEXECUTION_MODEを`all_phases`として内部的に設定することを検証
+
+**手順**:
+1. `AI_Workflow/infrastructure-as-code/all_phases`ジョブを開く
+2. 「Build with Parameters」をクリック
+3. パラメータを入力:
+   - ISSUE_URL: `https://github.com/tielec/infrastructure-as-code/issues/999` (ダミー)
+   - DRY_RUN: `true`
+   - その他はデフォルト
+4. 「Build」をクリック
+5. ビルドログを確認
+
+**期待結果**:
+- [ ] ビルドが開始される
+- [ ] ビルドログに`EXECUTION_MODE=all_phases`と記録される (または環境変数として設定される)
+- [ ] DRY_RUNモードのため、実際のAPI呼び出しは行わない
+- [ ] ビルドが成功（SUCCESS）で完了する
+
+**実行日**: ___________
+**結果**: ✅ PASS / ❌ FAIL
+**備考**: ___________________________________________
+
+---
+
+### TC-009: 全ジョブのEXECUTION_MODE一斉検証
+
+**目的**: 5つのジョブそれぞれが、正しいEXECUTION_MODEを設定していることを検証
+
+**手順**: 各ジョブについて以下を実行
+1. ジョブを開く
+2. 「Build with Parameters」をクリック
+3. 最小限のパラメータを入力（DRY_RUN=true）
+4. ビルドを実行
+5. ビルドログでEXECUTION_MODEの値を確認
+
+**期待結果**:
+
+| ジョブ名 | EXECUTION_MODE | ビルド結果 |
+|---------|----------------|-----------|
+| all_phases | all_phases | SUCCESS |
+| preset | preset | SUCCESS |
+| single_phase | single_phase | SUCCESS |
+| rollback | rollback | SUCCESS |
+| auto_issue | auto_issue | SUCCESS |
+
+- [ ] all_phases: `EXECUTION_MODE=all_phases`
+- [ ] preset: `EXECUTION_MODE=preset`
+- [ ] single_phase: `EXECUTION_MODE=single_phase`
+- [ ] rollback: `EXECUTION_MODE=rollback`
+- [ ] auto_issue: `EXECUTION_MODE=auto_issue`
+
+**実行日**: ___________
+**結果**: ✅ PASS / ❌ FAIL
+**備考**: ___________________________________________
+
+---
+
+## Test Suite 4: Jenkinsfile連携テスト
+
+### TC-010: Jenkinsfile参照設定の検証
+
+**目的**: 各ジョブが正しいJenkinsfile（ai-workflow-agentリポジトリ）を参照していることを検証
+
+**手順**:
+1. 各ジョブの設定画面（Configure）を開く
+2. 「Pipeline」セクションを確認
+
+**期待結果**:
+- [ ] 「Pipeline script from SCM」が選択されている
+- [ ] SCM: Git
+- [ ] Repository URL: `https://github.com/tielec/ai-workflow-agent.git`
+- [ ] Credentials: `github-token` (または適切なクレデンシャル)
+- [ ] Branch: `*/main`
+- [ ] Script Path: `Jenkinsfile`
+
+**実行日**: ___________
+**結果**: ✅ PASS / ❌ FAIL
+**備考**: ___________________________________________
+
+---
+
+## Test Suite 5: Deprecated化テスト
+
+### TC-011: 既存ジョブのDeprecated表示検証
+
+**目的**: 既存のai_workflow_orchestratorジョブが非推奨として正しく表示されることを検証
+
+**手順**:
+1. 既存の`ai_workflow_orchestrator`ジョブを開く（存在する場合）
+2. ジョブのdescription（説明文）を確認
+
+**期待結果**:
+- [ ] descriptionの冒頭に「⚠️ このジョブは非推奨です」と表示される
+- [ ] 新しいジョブへの移行案内が表示される
+- [ ] 5つの新しいジョブのパスが記載されている
+- [ ] 削除予定日が明記されている
+- [ ] ジョブは実行可能な状態である（後方互換性）
+
+**実行日**: ___________
+**結果**: ✅ PASS / ❌ FAIL
+**備考**: ___________________________________________
+
+---
+
+## Test Suite 6: エンドツーエンドテスト（DRY_RUN）
+
+### TC-012: all_phasesジョブの動作確認
+
+**目的**: 実際のIssue URLを使用して、all_phasesジョブが正常に動作することを検証
+
+**手順**:
+1. `AI_Workflow/infrastructure-as-code/all_phases`ジョブを開く
+2. 「Build with Parameters」をクリック
+3. パラメータを入力:
+   - ISSUE_URL: `https://github.com/tielec/infrastructure-as-code/issues/999` (テスト用)
+   - DRY_RUN: `true`
+   - その他はデフォルト
+4. ビルドを実行
+5. ビルドログを確認
+
+**期待結果**:
+- [ ] ビルドが開始される
+- [ ] Jenkinsfileがチェックアウトされる
+- [ ] `EXECUTION_MODE=all_phases`が設定される
+- [ ] DRY_RUNモードのため、実際の処理は行わないが、各フェーズのステップが表示される
+- [ ] ビルドが成功（SUCCESS）で完了する
+- [ ] ビルド時間が合理的な範囲内（DRY_RUNで数分以内）
+
+**実行日**: ___________
+**結果**: ✅ PASS / ❌ FAIL
+**備考**: ___________________________________________
+
+---
+
+### TC-013: presetジョブの動作確認
+
+**目的**: presetジョブが正常に動作することを検証
+
+**手順**:
+1. `AI_Workflow/infrastructure-as-code/preset`ジョブを開く
+2. 「Build with Parameters」をクリック
+3. パラメータを入力:
+   - ISSUE_URL: `https://github.com/tielec/infrastructure-as-code/issues/999`
+   - PRESET: `quick-fix`
+   - DRY_RUN: `true`
+4. ビルドを実行
+
+**期待結果**:
+- [ ] ビルドが成功（SUCCESS）で完了する
+- [ ] `EXECUTION_MODE=preset`が設定される
+- [ ] `PRESET=quick-fix`が設定される
+
+**実行日**: ___________
+**結果**: ✅ PASS / ❌ FAIL
+**備考**: ___________________________________________
+
+---
+
+### TC-014: single_phaseジョブの動作確認
+
+**目的**: single_phaseジョブが正常に動作することを検証
+
+**手順**:
+1. `AI_Workflow/infrastructure-as-code/single_phase`ジョブを開く
+2. 「Build with Parameters」をクリック
+3. パラメータを入力:
+   - ISSUE_URL: `https://github.com/tielec/infrastructure-as-code/issues/999`
+   - START_PHASE: `implementation`
+   - DRY_RUN: `true`
+4. ビルドを実行
+
+**期待結果**:
+- [ ] ビルドが成功（SUCCESS）で完了する
+- [ ] `EXECUTION_MODE=single_phase`が設定される
+- [ ] `START_PHASE=implementation`が設定される
+
+**実行日**: ___________
+**結果**: ✅ PASS / ❌ FAIL
+**備考**: ___________________________________________
+
+---
+
+### TC-015: rollbackジョブの動作確認
+
+**目的**: rollbackジョブが正常に動作することを検証
+
+**手順**:
+1. `AI_Workflow/infrastructure-as-code/rollback`ジョブを開く
+2. 「Build with Parameters」をクリック
+3. パラメータを入力:
+   - ISSUE_URL: `https://github.com/tielec/infrastructure-as-code/issues/999`
+   - ROLLBACK_TO_PHASE: `implementation`
+   - ROLLBACK_TO_STEP: `revise`
+   - ROLLBACK_REASON: `テストのための差し戻し`
+   - DRY_RUN: `true`
+4. ビルドを実行
+
+**期待結果**:
+- [ ] ビルドが成功（SUCCESS）で完了する
+- [ ] `EXECUTION_MODE=rollback`が設定される
+- [ ] `ROLLBACK_TO_PHASE=implementation`が設定される
+- [ ] `ROLLBACK_TO_STEP=revise`が設定される
+
+**実行日**: ___________
+**結果**: ✅ PASS / ❌ FAIL
+**備考**: ___________________________________________
+
+---
+
+### TC-016: auto_issueジョブの動作確認
+
+**目的**: auto_issueジョブが正常に動作することを検証
+
+**手順**:
+1. `AI_Workflow/infrastructure-as-code/auto_issue`ジョブを開く
+2. 「Build with Parameters」をクリック
+3. パラメータを入力:
+   - GITHUB_REPOSITORY: `tielec/infrastructure-as-code`
+   - AUTO_ISSUE_CATEGORY: `bug`
+   - AUTO_ISSUE_LIMIT: `5`
+   - AUTO_ISSUE_SIMILARITY_THRESHOLD: `0.8`
+   - DRY_RUN: `true`
+4. ビルドを実行
+
+**期待結果**:
+- [ ] ビルドが成功（SUCCESS）で完了する
+- [ ] `EXECUTION_MODE=auto_issue`が設定される
+- [ ] `GITHUB_REPOSITORY=tielec/infrastructure-as-code`が設定される
+- [ ] ISSUE_URLが設定されていない（auto_issueでは不要）
+
+**実行日**: ___________
+**結果**: ✅ PASS / ❌ FAIL
+**備考**: ___________________________________________
+
+---
+
+## Test Suite 7: スケーラビリティテスト
+
+### TC-017: 複数リポジトリでのジョブ生成
+
+**目的**: リポジトリ数が増加した場合、シードジョブが正常に動作し、すべてのジョブが生成されることを検証
+
+**手順**:
+1. `jenkinsManagedRepositories`に複数のリポジトリが登録されていることを確認
+2. シードジョブを実行
+3. ビルド完了時間を記録
+4. 生成されたジョブ数を確認
+
+**期待結果**:
+- [ ] シードジョブが成功（SUCCESS）で完了する
+- [ ] ビルド時間が5分以内である
+- [ ] 生成されたジョブ数 = リポジトリ数 × 5
+- [ ] すべてのジョブが正常に生成される
+
+**実行日**: ___________
+**結果**: ✅ PASS / ❌ FAIL
+**リポジトリ数**: _____
+**ビルド時間**: _____分_____秒
+**備考**: ___________________________________________
+
+---
+
+## テスト結果サマリー
+
+### 実施状況
+
+| Test Suite | テストケース数 | PASS | FAIL | 未実施 |
+|-----------|--------------|------|------|--------|
+| Suite 1: シードジョブ実行 | 2 | | | |
+| Suite 2: パラメータ定義 | 5 | | | |
+| Suite 3: EXECUTION_MODE設定 | 2 | | | |
+| Suite 4: Jenkinsfile連携 | 1 | | | |
+| Suite 5: Deprecated化 | 1 | | | |
+| Suite 6: エンドツーエンド | 5 | | | |
+| Suite 7: スケーラビリティ | 1 | | | |
+| **合計** | **17** | | | |
+
+### 成功率
+- 成功率: _____% (PASS数 / 総テストケース数 × 100)
+
+### 発見された問題
+
+| 問題ID | 問題内容 | 重要度 | 対応状況 | 担当者 |
+|--------|---------|--------|---------|--------|
+| | | | | |
+
+### 品質ゲート判定
+
+- [ ] **全テストケースが実行された**
+- [ ] **クリティカルな問題が0件**
+- [ ] **成功率が90%以上**
+
+**総合判定**: ✅ PASS / ❌ FAIL
+
+---
+
+## テスト実施時の注意事項
+
+1. **DRY_RUNモードの使用**: 実際のAPI呼び出しを行わないため、外部サービスへの影響を最小化
+2. **ダミーIssue URL**: テスト用のIssue URLを使用（例: #999）
+3. **ログの確認**: EXECUTION_MODEが正しく渡されているかをログで必ず確認
+4. **ビルド履歴の保持**: テスト実行後、ビルドログをスクリーンショットまたは保存
+5. **並行実行の禁止**: テスト実行中は他のビルドを実行しない
+
+---
+
+## 次のステップ
+
+このテストプランを実行した後:
+1. テスト結果サマリーを記録
+2. 発見された問題を記録
+3. 品質ゲートの判定を行う
+4. Phase 7（Documentation）に進む
+
+---
+
+**テストプラン作成者**: AI Workflow Agent
+**レビュー待ち**: Phase 5 (Test Implementation) Review

--- a/jenkins/jobs/dsl/ai-workflow/ai_workflow_all_phases_job.groovy
+++ b/jenkins/jobs/dsl/ai-workflow/ai_workflow_all_phases_job.groovy
@@ -1,0 +1,226 @@
+/**
+ * AI Workflow All Phases Job DSL
+ *
+ * 全フェーズ一括実行用ジョブ（planning → evaluation）
+ * EXECUTION_MODE: all_phases（固定値、パラメータとして表示しない）
+ * パラメータ数: 20個（14個 + APIキー6個）
+ */
+
+// 汎用フォルダ定義（Develop 1 + Stable 9）
+def genericFolders = [
+    [name: 'develop', displayName: 'AI Workflow Executor - Develop', branch: '*/develop']
+] + (1..9).collect { i ->
+    [name: "stable-${i}", displayName: "AI Workflow Executor - Stable ${i}", branch: '*/main']
+}
+
+// 共通設定を取得
+def jenkinsPipelineRepo = commonSettings['jenkins-pipeline-repo']
+def jobKey = 'ai_workflow_all_phases_job'
+def jobConfig = jenkinsJobsConfig[jobKey]
+
+// ジョブ作成クロージャ
+def createJob = { String jobName, String descriptionHeader, String gitBranch ->
+    pipelineJob(jobName) {
+        displayName(jobConfig.displayName)
+
+        description("""\
+            |# AI Workflow - All Phases Execution
+            |
+            |${descriptionHeader}
+            |
+            |## 概要
+            |全フェーズ（planning → evaluation）を順次実行します。
+            |resume機能により、失敗したフェーズから再開可能です。
+            |
+            |## パラメータ
+            |- ISSUE_URL（必須）: GitHub Issue URL
+            |- DRY_RUN: ドライランモード（デフォルト: false）
+            |- その他: 実行オプション、Git設定、AWS認証情報等
+            |
+            |## 注意事項
+            |- EXECUTION_MODEは内部的に'all_phases'に固定されます
+            |- コスト上限: デフォルト \$5.00 USD
+            """.stripMargin())
+
+        // パラメータ定義
+        parameters {
+            // ========================================
+            // 実行モード（固定値）
+            // ========================================
+            choiceParam('EXECUTION_MODE', ['all_phases'], '''
+実行モード（固定値 - 変更不可）
+            '''.stripIndent().trim())
+
+            // ========================================
+            // 基本設定
+            // ========================================
+            stringParam('ISSUE_URL', '', '''
+GitHub Issue URL（必須）
+
+例: https://github.com/tielec/my-project/issues/123
+注: Issue URL から対象リポジトリを自動判定します
+            '''.stripIndent().trim())
+
+            stringParam('BRANCH_NAME', '', '''
+作業ブランチ名（任意）
+空欄の場合は Issue 番号から自動生成されます
+            '''.stripIndent().trim())
+
+            choiceParam('AGENT_MODE', ['auto', 'codex', 'claude'], '''
+エージェントの実行モード
+- auto: Codex APIキーがあれば Codex を優先し、なければ Claude Code を使用
+- codex: Codex のみを使用（CODEX_API_KEY または OPENAI_API_KEY が必要）
+- claude: Claude Code のみを使用（credentials.json が必要）
+            '''.stripIndent().trim())
+
+            // ========================================
+            // 実行オプション
+            // ========================================
+            booleanParam('DRY_RUN', false, '''
+ドライランモード（API 呼び出しや Git 操作を行わず動作確認のみ実施）
+            '''.stripIndent().trim())
+
+            booleanParam('SKIP_REVIEW', false, '''
+AI レビューをスキップする（検証・デバッグ用）
+            '''.stripIndent().trim())
+
+            booleanParam('FORCE_RESET', false, '''
+メタデータを初期化して最初から実行する
+            '''.stripIndent().trim())
+
+            choiceParam('MAX_RETRIES', ['3', '1', '5', '10'], '''
+フェーズ失敗時の最大リトライ回数
+            '''.stripIndent().trim())
+
+            booleanParam('CLEANUP_ON_COMPLETE_FORCE', false, '''
+Evaluation Phase完了後にワークフローディレクトリを強制削除
+詳細: Issue #2、v0.3.0で追加
+            '''.stripIndent().trim())
+
+            booleanParam('SQUASH_ON_COMPLETE', true, '''
+ワークフロー完了時にコミットをスカッシュする
+            '''.stripIndent().trim())
+
+            // ========================================
+            // Git 設定
+            // ========================================
+            stringParam('GIT_COMMIT_USER_NAME', 'AI Workflow Bot', '''
+Git コミットユーザー名
+            '''.stripIndent().trim())
+
+            stringParam('GIT_COMMIT_USER_EMAIL', 'ai-workflow@example.com', '''
+Git コミットメールアドレス
+            '''.stripIndent().trim())
+
+            // ========================================
+            // AWS 認証情報（Infrastructure as Code 用）
+            // ========================================
+            stringParam('AWS_ACCESS_KEY_ID', '', '''
+AWS アクセスキー ID（任意）
+Infrastructure as Code実行時に必要
+            '''.stripIndent().trim())
+
+            nonStoredPasswordParam('AWS_SECRET_ACCESS_KEY', '''
+AWS シークレットアクセスキー（任意）
+Infrastructure as Code実行時に必要
+            '''.stripIndent().trim())
+
+            nonStoredPasswordParam('AWS_SESSION_TOKEN', '''
+AWS セッショントークン（任意）
+一時的な認証情報を使用する場合
+            '''.stripIndent().trim())
+
+            // ========================================
+            // APIキー設定
+            // ========================================
+            nonStoredPasswordParam('GITHUB_TOKEN', '''
+GitHub Personal Access Token（任意）
+GitHub API呼び出しに使用されます
+            '''.stripIndent().trim())
+
+            nonStoredPasswordParam('OPENAI_API_KEY', '''
+OpenAI API キー（任意）
+Codex実行モードで使用されます
+            '''.stripIndent().trim())
+
+            nonStoredPasswordParam('CODEX_API_KEY', '''
+Codex API キー（任意）
+OPENAI_API_KEYの代替として使用可能
+            '''.stripIndent().trim())
+
+            nonStoredPasswordParam('CLAUDE_CODE_OAUTH_TOKEN', '''
+Claude Code OAuth トークン（任意）
+Claude実行モードで使用されます
+            '''.stripIndent().trim())
+
+            nonStoredPasswordParam('CLAUDE_CODE_API_KEY', '''
+Claude Code API キー（任意）
+Claude実行モードで使用されます
+            '''.stripIndent().trim())
+
+            nonStoredPasswordParam('ANTHROPIC_API_KEY', '''
+Anthropic API キー（任意）
+Claude実行モードで使用されます
+            '''.stripIndent().trim())
+
+            // ========================================
+            // その他
+            // ========================================
+            stringParam('COST_LIMIT_USD', '5.0', '''
+ワークフローあたりのコスト上限（USD）
+            '''.stripIndent().trim())
+
+            choiceParam('LOG_LEVEL', ['INFO', 'DEBUG', 'WARNING', 'ERROR'], '''
+ログレベル
+- INFO: 一般的な情報
+- DEBUG: 詳細ログ（デバッグ用）
+- WARNING / ERROR: 警告 / エラーのみ
+            '''.stripIndent().trim())
+        }
+
+        // ログローテーション
+        logRotator {
+            numToKeep(30)
+            daysToKeep(90)
+        }
+
+        // パイプライン定義
+        definition {
+            cpsScm {
+                scm {
+                    git {
+                        remote {
+                            url('https://github.com/tielec/ai-workflow-agent.git')
+                            credentials('github-token')
+                        }
+                        branch(gitBranch)
+                    }
+                }
+                scriptPath('Jenkinsfile')
+            }
+        }
+
+        // 環境変数（EXECUTION_MODEを固定値として設定）
+        environmentVariables {
+            env('EXECUTION_MODE', 'all_phases')
+            env('WORKFLOW_VERSION', '0.2.0')
+        }
+
+        // プロパティ
+        properties {
+            disableConcurrentBuilds()
+        }
+
+        // ジョブの無効化状態
+        disabled(false)
+    }
+}
+
+// 汎用フォルダ用ジョブを作成
+genericFolders.each { folder ->
+    createJob(
+        "AI_Workflow/${folder.name}/${jobConfig.name}",
+        "フォルダ: ${folder.displayName}\nブランチ: ${folder.branch}",
+        folder.branch
+    )
+}

--- a/jenkins/jobs/dsl/ai-workflow/ai_workflow_auto_issue_job.groovy
+++ b/jenkins/jobs/dsl/ai-workflow/ai_workflow_auto_issue_job.groovy
@@ -1,0 +1,200 @@
+/**
+ * AI Workflow Auto Issue Job DSL
+ *
+ * AIによる自動Issue作成用ジョブ
+ * EXECUTION_MODE: auto_issue（固定値、パラメータとして表示しない）
+ * パラメータ数: 14個（8個 + APIキー6個）
+ */
+
+// 汎用フォルダ定義（Develop 1 + Stable 9）
+def genericFolders = [
+    [name: 'develop', displayName: 'AI Workflow Executor - Develop', branch: '*/develop']
+] + (1..9).collect { i ->
+    [name: "stable-${i}", displayName: "AI Workflow Executor - Stable ${i}", branch: '*/main']
+}
+
+// 共通設定を取得
+def jenkinsPipelineRepo = commonSettings['jenkins-pipeline-repo']
+def jobKey = 'ai_workflow_auto_issue_job'
+def jobConfig = jenkinsJobsConfig[jobKey]
+
+// ジョブ作成クロージャ
+def createJob = { String jobName, String descriptionHeader, String gitBranch ->
+    pipelineJob(jobName) {
+        displayName(jobConfig.displayName)
+
+        description("""\
+            |# AI Workflow - Auto Issue Creation
+            |
+            |${descriptionHeader}
+            |
+            |## 概要
+            |AIエージェントがリポジトリを探索し、バグや改善点を検出してIssueを自動作成します。
+            |
+            |## Issue検出カテゴリ
+            |- bug: バグ・潜在的問題の検出（Phase 1で実装済み）
+            |- refactor: リファクタリング候補の検出（Phase 2で実装予定）
+            |- enhancement: 機能拡張提案（Phase 3で実装予定）
+            |- all: 全カテゴリを検出
+            |
+            |## 機能
+            |- 重複判定の類似度閾値設定（デフォルト: 0.8）
+            |- 作成するIssueの最大数設定（デフォルト: 5）
+            |
+            |## 注意事項
+            |- EXECUTION_MODEは内部的に'auto_issue'に固定されます
+            |- ISSUE_URLは不要（リポジトリ探索により自動Issue作成）
+            |- コスト上限: デフォルト \$5.00 USD
+            """.stripMargin())
+
+        // パラメータ定義
+        parameters {
+            // ========================================
+            // 実行モード（固定値）
+            // ========================================
+            choiceParam('EXECUTION_MODE', ['auto_issue'], '''
+実行モード（固定値 - 変更不可）
+            '''.stripIndent().trim())
+
+            // ========================================
+            // 基本設定
+            // ========================================
+            stringParam('GITHUB_REPOSITORY', '', '''
+GitHub リポジトリ（owner/repo）（必須）
+
+例: tielec/ai-workflow-agent
+            '''.stripIndent().trim())
+
+            choiceParam('AGENT_MODE', ['auto', 'codex', 'claude'], '''
+エージェントの実行モード
+- auto: Codex APIキーがあれば Codex を優先し、なければ Claude Code を使用
+- codex: Codex のみを使用（CODEX_API_KEY または OPENAI_API_KEY が必要）
+- claude: Claude Code のみを使用（credentials.json が必要）
+            '''.stripIndent().trim())
+
+            // ========================================
+            // Auto Issue 設定
+            // ========================================
+            choiceParam('AUTO_ISSUE_CATEGORY', ['bug', 'refactor', 'enhancement', 'all'], '''
+Issue検出カテゴリ
+
+- bug: バグ・潜在的問題の検出（Phase 1で実装済み）
+- refactor: リファクタリング候補の検出（Phase 2で実装予定）
+- enhancement: 機能拡張提案（Phase 3で実装予定）
+- all: 全カテゴリを検出
+            '''.stripIndent().trim())
+
+            stringParam('AUTO_ISSUE_LIMIT', '5', '''
+作成するIssueの最大数
+
+1〜50の範囲で指定してください。
+            '''.stripIndent().trim())
+
+            stringParam('AUTO_ISSUE_SIMILARITY_THRESHOLD', '0.8', '''
+重複判定の類似度閾値
+
+0.0〜1.0の範囲で指定してください。
+値が高いほど厳密に重複判定します（デフォルト: 0.8）。
+            '''.stripIndent().trim())
+
+            // ========================================
+            // 実行オプション
+            // ========================================
+            booleanParam('DRY_RUN', false, '''
+ドライランモード（API 呼び出しや Git 操作を行わず動作確認のみ実施）
+            '''.stripIndent().trim())
+
+            // ========================================
+            // APIキー設定
+            // ========================================
+            nonStoredPasswordParam('GITHUB_TOKEN', '''
+GitHub Personal Access Token（任意）
+GitHub API呼び出しに使用されます
+            '''.stripIndent().trim())
+
+            nonStoredPasswordParam('OPENAI_API_KEY', '''
+OpenAI API キー（任意）
+Codex実行モードで使用されます
+            '''.stripIndent().trim())
+
+            nonStoredPasswordParam('CODEX_API_KEY', '''
+Codex API キー（任意）
+OPENAI_API_KEYの代替として使用可能
+            '''.stripIndent().trim())
+
+            nonStoredPasswordParam('CLAUDE_CODE_OAUTH_TOKEN', '''
+Claude Code OAuth トークン（任意）
+Claude実行モードで使用されます
+            '''.stripIndent().trim())
+
+            nonStoredPasswordParam('CLAUDE_CODE_API_KEY', '''
+Claude Code API キー（任意）
+Claude実行モードで使用されます
+            '''.stripIndent().trim())
+
+            nonStoredPasswordParam('ANTHROPIC_API_KEY', '''
+Anthropic API キー（任意）
+Claude実行モードで使用されます
+            '''.stripIndent().trim())
+
+            // ========================================
+            // その他
+            // ========================================
+            stringParam('COST_LIMIT_USD', '5.0', '''
+ワークフローあたりのコスト上限（USD）
+            '''.stripIndent().trim())
+
+            choiceParam('LOG_LEVEL', ['INFO', 'DEBUG', 'WARNING', 'ERROR'], '''
+ログレベル
+- INFO: 一般的な情報
+- DEBUG: 詳細ログ（デバッグ用）
+- WARNING / ERROR: 警告 / エラーのみ
+            '''.stripIndent().trim())
+        }
+
+        // ログローテーション
+        logRotator {
+            numToKeep(30)
+            daysToKeep(90)
+        }
+
+        // パイプライン定義
+        definition {
+            cpsScm {
+                scm {
+                    git {
+                        remote {
+                            url('https://github.com/tielec/ai-workflow-agent.git')
+                            credentials('github-token')
+                        }
+                        branch(gitBranch)
+                    }
+                }
+                scriptPath('Jenkinsfile')
+            }
+        }
+
+        // 環境変数（EXECUTION_MODEを固定値として設定）
+        environmentVariables {
+            env('EXECUTION_MODE', 'auto_issue')
+            env('WORKFLOW_VERSION', '0.2.0')
+        }
+
+        // プロパティ
+        properties {
+            disableConcurrentBuilds()
+        }
+
+        // ジョブの無効化状態
+        disabled(false)
+    }
+}
+
+// 汎用フォルダ用ジョブを作成
+genericFolders.each { folder ->
+    createJob(
+        "AI_Workflow/${folder.name}/${jobConfig.name}",
+        "フォルダ: ${folder.displayName}\nブランチ: ${folder.branch}",
+        folder.branch
+    )
+}

--- a/jenkins/jobs/dsl/ai-workflow/ai_workflow_preset_job.groovy
+++ b/jenkins/jobs/dsl/ai-workflow/ai_workflow_preset_job.groovy
@@ -1,0 +1,244 @@
+/**
+ * AI Workflow Preset Job DSL
+ *
+ * プリセット実行用ジョブ（定義済みワークフローパターンを実行）
+ * EXECUTION_MODE: preset（固定値、パラメータとして表示しない）
+ * パラメータ数: 21個（all_phasesの14個 + PRESET + APIキー6個）
+ */
+
+// 汎用フォルダ定義（Develop 1 + Stable 9）
+def genericFolders = [
+    [name: 'develop', displayName: 'AI Workflow Executor - Develop', branch: '*/develop']
+] + (1..9).collect { i ->
+    [name: "stable-${i}", displayName: "AI Workflow Executor - Stable ${i}", branch: '*/main']
+}
+
+// 共通設定を取得
+def jenkinsPipelineRepo = commonSettings['jenkins-pipeline-repo']
+def jobKey = 'ai_workflow_preset_job'
+def jobConfig = jenkinsJobsConfig[jobKey]
+
+// ジョブ作成クロージャ
+def createJob = { String jobName, String descriptionHeader, String gitBranch ->
+    pipelineJob(jobName) {
+        displayName(jobConfig.displayName)
+
+        description("""\
+            |# AI Workflow - Preset Execution
+            |
+            |${descriptionHeader}
+            |
+            |## 概要
+            |定義済みワークフローパターンを実行します（quick-fix, implementation等）。
+            |
+            |## プリセット
+            |- quick-fix: 軽微な修正用（Implementation → Documentation → Report）
+            |- implementation: 通常の実装フロー（Implementation → TestImplementation → Testing → Documentation → Report）
+            |- testing: テスト追加用（TestImplementation → Testing）
+            |- review-requirements: 要件定義レビュー用（Planning → Requirements）
+            |- review-design: 設計レビュー用（Planning → Requirements → Design）
+            |- review-test-scenario: テストシナリオレビュー用（Planning → Requirements → Design → TestScenario）
+            |- finalize: 最終化用（Documentation → Report → Evaluation）
+            |
+            |## 注意事項
+            |- EXECUTION_MODEは内部的に'preset'に固定されます
+            |- コスト上限: デフォルト \$5.00 USD
+            """.stripMargin())
+
+        // パラメータ定義
+        parameters {
+            // ========================================
+            // 実行モード（固定値）
+            // ========================================
+            choiceParam('EXECUTION_MODE', ['preset'], '''
+実行モード（固定値 - 変更不可）
+            '''.stripIndent().trim())
+
+            // ========================================
+            // 基本設定
+            // ========================================
+            stringParam('ISSUE_URL', '', '''
+GitHub Issue URL（必須）
+
+例: https://github.com/tielec/my-project/issues/123
+注: Issue URL から対象リポジトリを自動判定します
+            '''.stripIndent().trim())
+
+            stringParam('BRANCH_NAME', '', '''
+作業ブランチ名（任意）
+空欄の場合は Issue 番号から自動生成されます
+            '''.stripIndent().trim())
+
+            choiceParam('AGENT_MODE', ['auto', 'codex', 'claude'], '''
+エージェントの実行モード
+- auto: Codex APIキーがあれば Codex を優先し、なければ Claude Code を使用
+- codex: Codex のみを使用（CODEX_API_KEY または OPENAI_API_KEY が必要）
+- claude: Claude Code のみを使用（credentials.json が必要）
+            '''.stripIndent().trim())
+
+            // ========================================
+            // プリセット設定
+            // ========================================
+            choiceParam('PRESET', ['quick-fix', 'implementation', 'testing', 'review-requirements', 'review-design', 'review-test-scenario', 'finalize'], '''
+プリセット（必須）
+
+- quick-fix: 軽微な修正用（Implementation → Documentation → Report）
+- implementation: 通常の実装フロー（Implementation → TestImplementation → Testing → Documentation → Report）
+- testing: テスト追加用（TestImplementation → Testing）
+- review-requirements: 要件定義レビュー用（Planning → Requirements）
+- review-design: 設計レビュー用（Planning → Requirements → Design）
+- review-test-scenario: テストシナリオレビュー用（Planning → Requirements → Design → TestScenario）
+- finalize: 最終化用（Documentation → Report → Evaluation）
+            '''.stripIndent().trim())
+
+            // ========================================
+            // 実行オプション
+            // ========================================
+            booleanParam('DRY_RUN', false, '''
+ドライランモード（API 呼び出しや Git 操作を行わず動作確認のみ実施）
+            '''.stripIndent().trim())
+
+            booleanParam('SKIP_REVIEW', false, '''
+AI レビューをスキップする（検証・デバッグ用）
+            '''.stripIndent().trim())
+
+            booleanParam('FORCE_RESET', false, '''
+メタデータを初期化して最初から実行する
+            '''.stripIndent().trim())
+
+            choiceParam('MAX_RETRIES', ['3', '1', '5', '10'], '''
+フェーズ失敗時の最大リトライ回数
+            '''.stripIndent().trim())
+
+            booleanParam('CLEANUP_ON_COMPLETE_FORCE', false, '''
+Evaluation Phase完了後にワークフローディレクトリを強制削除
+詳細: Issue #2、v0.3.0で追加
+            '''.stripIndent().trim())
+
+            booleanParam('SQUASH_ON_COMPLETE', true, '''
+ワークフロー完了時にコミットをスカッシュする
+            '''.stripIndent().trim())
+
+            // ========================================
+            // Git 設定
+            // ========================================
+            stringParam('GIT_COMMIT_USER_NAME', 'AI Workflow Bot', '''
+Git コミットユーザー名
+            '''.stripIndent().trim())
+
+            stringParam('GIT_COMMIT_USER_EMAIL', 'ai-workflow@example.com', '''
+Git コミットメールアドレス
+            '''.stripIndent().trim())
+
+            // ========================================
+            // AWS 認証情報（Infrastructure as Code 用）
+            // ========================================
+            stringParam('AWS_ACCESS_KEY_ID', '', '''
+AWS アクセスキー ID（任意）
+Infrastructure as Code実行時に必要
+            '''.stripIndent().trim())
+
+            nonStoredPasswordParam('AWS_SECRET_ACCESS_KEY', '''
+AWS シークレットアクセスキー（任意）
+Infrastructure as Code実行時に必要
+            '''.stripIndent().trim())
+
+            nonStoredPasswordParam('AWS_SESSION_TOKEN', '''
+AWS セッショントークン（任意）
+一時的な認証情報を使用する場合
+            '''.stripIndent().trim())
+
+            // ========================================
+            // APIキー設定
+            // ========================================
+            nonStoredPasswordParam('GITHUB_TOKEN', '''
+GitHub Personal Access Token（任意）
+GitHub API呼び出しに使用されます
+            '''.stripIndent().trim())
+
+            nonStoredPasswordParam('OPENAI_API_KEY', '''
+OpenAI API キー（任意）
+Codex実行モードで使用されます
+            '''.stripIndent().trim())
+
+            nonStoredPasswordParam('CODEX_API_KEY', '''
+Codex API キー（任意）
+OPENAI_API_KEYの代替として使用可能
+            '''.stripIndent().trim())
+
+            nonStoredPasswordParam('CLAUDE_CODE_OAUTH_TOKEN', '''
+Claude Code OAuth トークン（任意）
+Claude実行モードで使用されます
+            '''.stripIndent().trim())
+
+            nonStoredPasswordParam('CLAUDE_CODE_API_KEY', '''
+Claude Code API キー（任意）
+Claude実行モードで使用されます
+            '''.stripIndent().trim())
+
+            nonStoredPasswordParam('ANTHROPIC_API_KEY', '''
+Anthropic API キー（任意）
+Claude実行モードで使用されます
+            '''.stripIndent().trim())
+
+            // ========================================
+            // その他
+            // ========================================
+            stringParam('COST_LIMIT_USD', '5.0', '''
+ワークフローあたりのコスト上限（USD）
+            '''.stripIndent().trim())
+
+            choiceParam('LOG_LEVEL', ['INFO', 'DEBUG', 'WARNING', 'ERROR'], '''
+ログレベル
+- INFO: 一般的な情報
+- DEBUG: 詳細ログ（デバッグ用）
+- WARNING / ERROR: 警告 / エラーのみ
+            '''.stripIndent().trim())
+        }
+
+        // ログローテーション
+        logRotator {
+            numToKeep(30)
+            daysToKeep(90)
+        }
+
+        // パイプライン定義
+        definition {
+            cpsScm {
+                scm {
+                    git {
+                        remote {
+                            url('https://github.com/tielec/ai-workflow-agent.git')
+                            credentials('github-token')
+                        }
+                        branch(gitBranch)
+                    }
+                }
+                scriptPath('Jenkinsfile')
+            }
+        }
+
+        // 環境変数（EXECUTION_MODEを固定値として設定）
+        environmentVariables {
+            env('EXECUTION_MODE', 'preset')
+            env('WORKFLOW_VERSION', '0.2.0')
+        }
+
+        // プロパティ
+        properties {
+            disableConcurrentBuilds()
+        }
+
+        // ジョブの無効化状態
+        disabled(false)
+    }
+}
+
+// 汎用フォルダ用ジョブを作成
+genericFolders.each { folder ->
+    createJob(
+        "AI_Workflow/${folder.name}/${jobConfig.name}",
+        "フォルダ: ${folder.displayName}\nブランチ: ${folder.branch}",
+        folder.branch
+    )
+}

--- a/jenkins/jobs/dsl/ai-workflow/ai_workflow_rollback_job.groovy
+++ b/jenkins/jobs/dsl/ai-workflow/ai_workflow_rollback_job.groovy
@@ -1,0 +1,246 @@
+/**
+ * AI Workflow Rollback Job DSL
+ *
+ * フェーズ差し戻し実行用ジョブ
+ * EXECUTION_MODE: rollback（固定値、パラメータとして表示しない）
+ * パラメータ数: 18個（12個 + APIキー6個）
+ */
+
+// 汎用フォルダ定義（Develop 1 + Stable 9）
+def genericFolders = [
+    [name: 'develop', displayName: 'AI Workflow Executor - Develop', branch: '*/develop']
+] + (1..9).collect { i ->
+    [name: "stable-${i}", displayName: "AI Workflow Executor - Stable ${i}", branch: '*/main']
+}
+
+// 共通設定を取得
+def jenkinsPipelineRepo = commonSettings['jenkins-pipeline-repo']
+def jobKey = 'ai_workflow_rollback_job'
+def jobConfig = jenkinsJobsConfig[jobKey]
+
+// ジョブ作成クロージャ
+def createJob = { String jobName, String descriptionHeader, String gitBranch ->
+    pipelineJob(jobName) {
+        displayName(jobConfig.displayName)
+
+        description("""\
+            |# AI Workflow - Rollback Execution
+            |
+            |${descriptionHeader}
+            |
+            |## 概要
+            |フェーズを差し戻し、指定したフェーズから再実行します。
+            |メタデータが更新され、指定されたフェーズから再開可能になります。
+            |
+            |## 差し戻し先フェーズ
+            |- implementation: 実装
+            |- planning: 計画
+            |- requirements: 要件定義
+            |- design: 詳細設計
+            |- test_scenario: テストシナリオ
+            |- test_implementation: テスト実装
+            |- testing: テスト実行
+            |- documentation: ドキュメント作成
+            |- report: レポート作成
+            |
+            |注: evaluation フェーズへの差し戻しはできません
+            |
+            |## 注意事項
+            |- EXECUTION_MODEは内部的に'rollback'に固定されます
+            |- コスト上限: デフォルト \$5.00 USD
+            """.stripMargin())
+
+        // パラメータ定義
+        parameters {
+            // ========================================
+            // 実行モード（固定値）
+            // ========================================
+            choiceParam('EXECUTION_MODE', ['rollback'], '''
+実行モード（固定値 - 変更不可）
+            '''.stripIndent().trim())
+
+            // ========================================
+            // 基本設定
+            // ========================================
+            stringParam('ISSUE_URL', '', '''
+GitHub Issue URL（必須）
+
+例: https://github.com/tielec/my-project/issues/123
+注: Issue URL から対象リポジトリを自動判定します
+            '''.stripIndent().trim())
+
+            stringParam('BRANCH_NAME', '', '''
+作業ブランチ名（任意）
+空欄の場合は Issue 番号から自動生成されます
+            '''.stripIndent().trim())
+
+            choiceParam('AGENT_MODE', ['auto', 'codex', 'claude'], '''
+エージェントの実行モード
+- auto: Codex APIキーがあれば Codex を優先し、なければ Claude Code を使用
+- codex: Codex のみを使用（CODEX_API_KEY または OPENAI_API_KEY が必要）
+- claude: Claude Code のみを使用（credentials.json が必要）
+            '''.stripIndent().trim())
+
+            // ========================================
+            // Rollback 設定
+            // ========================================
+            choiceParam('ROLLBACK_TO_PHASE', ['implementation', 'planning', 'requirements', 'design', 'test_scenario', 'test_implementation', 'testing', 'documentation', 'report'], '''
+差し戻し先フェーズ（必須）
+
+差し戻したいフェーズを指定します。メタデータが更新され、指定されたフェーズから再実行可能になります。
+注: evaluation フェーズへの差し戻しはできません。
+            '''.stripIndent().trim())
+
+            choiceParam('ROLLBACK_TO_STEP', ['revise', 'execute', 'review'], '''
+差し戻し先ステップ（任意）
+
+デフォルトは revise です。
+- execute: フェーズの最初から再実行
+- review: レビューステップから再実行
+- revise: 修正ステップから再実行（差し戻し理由がプロンプトに注入されます）
+            '''.stripIndent().trim())
+
+            textParam('ROLLBACK_REASON', '', '''
+差し戻し理由（任意）
+
+差し戻しの理由を記述します。この内容は revise プロンプトに自動注入されます。
+空欄の場合、CI環境では差し戻しが実行されません（インタラクティブ入力が必要）。
+            '''.stripIndent().trim())
+
+            stringParam('ROLLBACK_REASON_FILE', '', '''
+差し戻し理由ファイルパス（任意）
+
+差し戻し理由を記述したファイルのパスを指定します。
+ROLLBACK_REASON と ROLLBACK_REASON_FILE の両方が指定された場合、ROLLBACK_REASON_FILE が優先されます。
+            '''.stripIndent().trim())
+
+            // ========================================
+            // 実行オプション
+            // ========================================
+            booleanParam('DRY_RUN', false, '''
+ドライランモード（API 呼び出しや Git 操作を行わず動作確認のみ実施）
+            '''.stripIndent().trim())
+
+            // ========================================
+            // Git 設定
+            // ========================================
+            stringParam('GIT_COMMIT_USER_NAME', 'AI Workflow Bot', '''
+Git コミットユーザー名
+            '''.stripIndent().trim())
+
+            stringParam('GIT_COMMIT_USER_EMAIL', 'ai-workflow@example.com', '''
+Git コミットメールアドレス
+            '''.stripIndent().trim())
+
+            // ========================================
+            // AWS 認証情報（Infrastructure as Code 用）
+            // ========================================
+            stringParam('AWS_ACCESS_KEY_ID', '', '''
+AWS アクセスキー ID（任意）
+Infrastructure as Code実行時に必要
+            '''.stripIndent().trim())
+
+            nonStoredPasswordParam('AWS_SECRET_ACCESS_KEY', '''
+AWS シークレットアクセスキー（任意）
+Infrastructure as Code実行時に必要
+            '''.stripIndent().trim())
+
+            nonStoredPasswordParam('AWS_SESSION_TOKEN', '''
+AWS セッショントークン（任意）
+一時的な認証情報を使用する場合
+            '''.stripIndent().trim())
+
+            // ========================================
+            // APIキー設定
+            // ========================================
+            nonStoredPasswordParam('GITHUB_TOKEN', '''
+GitHub Personal Access Token（任意）
+GitHub API呼び出しに使用されます
+            '''.stripIndent().trim())
+
+            nonStoredPasswordParam('OPENAI_API_KEY', '''
+OpenAI API キー（任意）
+Codex実行モードで使用されます
+            '''.stripIndent().trim())
+
+            nonStoredPasswordParam('CODEX_API_KEY', '''
+Codex API キー（任意）
+OPENAI_API_KEYの代替として使用可能
+            '''.stripIndent().trim())
+
+            nonStoredPasswordParam('CLAUDE_CODE_OAUTH_TOKEN', '''
+Claude Code OAuth トークン（任意）
+Claude実行モードで使用されます
+            '''.stripIndent().trim())
+
+            nonStoredPasswordParam('CLAUDE_CODE_API_KEY', '''
+Claude Code API キー（任意）
+Claude実行モードで使用されます
+            '''.stripIndent().trim())
+
+            nonStoredPasswordParam('ANTHROPIC_API_KEY', '''
+Anthropic API キー（任意）
+Claude実行モードで使用されます
+            '''.stripIndent().trim())
+
+            // ========================================
+            // その他
+            // ========================================
+            stringParam('COST_LIMIT_USD', '5.0', '''
+ワークフローあたりのコスト上限（USD）
+            '''.stripIndent().trim())
+
+            choiceParam('LOG_LEVEL', ['INFO', 'DEBUG', 'WARNING', 'ERROR'], '''
+ログレベル
+- INFO: 一般的な情報
+- DEBUG: 詳細ログ（デバッグ用）
+- WARNING / ERROR: 警告 / エラーのみ
+            '''.stripIndent().trim())
+        }
+
+        // ログローテーション
+        logRotator {
+            numToKeep(30)
+            daysToKeep(90)
+        }
+
+        // パイプライン定義
+        definition {
+            cpsScm {
+                scm {
+                    git {
+                        remote {
+                            url('https://github.com/tielec/ai-workflow-agent.git')
+                            credentials('github-token')
+                        }
+                        branch(gitBranch)
+                    }
+                }
+                scriptPath('Jenkinsfile')
+            }
+        }
+
+        // 環境変数（EXECUTION_MODEを固定値として設定）
+        environmentVariables {
+            env('EXECUTION_MODE', 'rollback')
+            env('WORKFLOW_VERSION', '0.2.0')
+        }
+
+        // プロパティ
+        properties {
+            disableConcurrentBuilds()
+        }
+
+        // ジョブの無効化状態
+        disabled(false)
+    }
+}
+
+// 汎用フォルダ用ジョブを作成
+genericFolders.each { folder ->
+    createJob(
+        "AI_Workflow/${folder.name}/${jobConfig.name}",
+        "フォルダ: ${folder.displayName}\nブランチ: ${folder.branch}",
+        folder.branch
+    )
+}

--- a/jenkins/jobs/dsl/ai-workflow/ai_workflow_single_phase_job.groovy
+++ b/jenkins/jobs/dsl/ai-workflow/ai_workflow_single_phase_job.groovy
@@ -1,0 +1,232 @@
+/**
+ * AI Workflow Single Phase Job DSL
+ *
+ * 単一フェーズ実行用ジョブ（指定フェーズのみ実行）
+ * EXECUTION_MODE: single_phase（固定値、パラメータとして表示しない）
+ * パラメータ数: 19個（13個 + APIキー6個）
+ */
+
+// 汎用フォルダ定義（Develop 1 + Stable 9）
+def genericFolders = [
+    [name: 'develop', displayName: 'AI Workflow Executor - Develop', branch: '*/develop']
+] + (1..9).collect { i ->
+    [name: "stable-${i}", displayName: "AI Workflow Executor - Stable ${i}", branch: '*/main']
+}
+
+// 共通設定を取得
+def jenkinsPipelineRepo = commonSettings['jenkins-pipeline-repo']
+def jobKey = 'ai_workflow_single_phase_job'
+def jobConfig = jenkinsJobsConfig[jobKey]
+
+// ジョブ作成クロージャ
+def createJob = { String jobName, String descriptionHeader, String gitBranch ->
+    pipelineJob(jobName) {
+        displayName(jobConfig.displayName)
+
+        description("""\
+            |# AI Workflow - Single Phase Execution
+            |
+            |${descriptionHeader}
+            |
+            |## 概要
+            |指定した単一フェーズのみを実行します（デバッグ用）。
+            |
+            |## フェーズ
+            |- planning: 計画
+            |- requirements: 要件定義
+            |- design: 詳細設計
+            |- test_scenario: テストシナリオ
+            |- implementation: 実装
+            |- test_implementation: テスト実装
+            |- testing: テスト実行
+            |- documentation: ドキュメント作成
+            |- report: レポート作成
+            |- evaluation: 評価
+            |
+            |## 注意事項
+            |- EXECUTION_MODEは内部的に'single_phase'に固定されます
+            |- コスト上限: デフォルト \$5.00 USD
+            """.stripMargin())
+
+        // パラメータ定義
+        parameters {
+            // ========================================
+            // 実行モード（固定値）
+            // ========================================
+            choiceParam('EXECUTION_MODE', ['single_phase'], '''
+実行モード（固定値 - 変更不可）
+            '''.stripIndent().trim())
+
+            // ========================================
+            // 基本設定
+            // ========================================
+            stringParam('ISSUE_URL', '', '''
+GitHub Issue URL（必須）
+
+例: https://github.com/tielec/my-project/issues/123
+注: Issue URL から対象リポジトリを自動判定します
+            '''.stripIndent().trim())
+
+            stringParam('BRANCH_NAME', '', '''
+作業ブランチ名（任意）
+空欄の場合は Issue 番号から自動生成されます
+            '''.stripIndent().trim())
+
+            choiceParam('AGENT_MODE', ['auto', 'codex', 'claude'], '''
+エージェントの実行モード
+- auto: Codex APIキーがあれば Codex を優先し、なければ Claude Code を使用
+- codex: Codex のみを使用（CODEX_API_KEY または OPENAI_API_KEY が必要）
+- claude: Claude Code のみを使用（credentials.json が必要）
+            '''.stripIndent().trim())
+
+            // ========================================
+            // フェーズ指定
+            // ========================================
+            choiceParam('START_PHASE', ['planning', 'requirements', 'design', 'test_scenario', 'implementation', 'test_implementation', 'testing', 'documentation', 'report', 'evaluation'], '''
+開始フェーズ（必須）
+
+指定したフェーズのみを実行します
+            '''.stripIndent().trim())
+
+            // ========================================
+            // 実行オプション
+            // ========================================
+            booleanParam('DRY_RUN', false, '''
+ドライランモード（API 呼び出しや Git 操作を行わず動作確認のみ実施）
+            '''.stripIndent().trim())
+
+            booleanParam('SKIP_REVIEW', false, '''
+AI レビューをスキップする（検証・デバッグ用）
+            '''.stripIndent().trim())
+
+            choiceParam('MAX_RETRIES', ['3', '1', '5', '10'], '''
+フェーズ失敗時の最大リトライ回数
+            '''.stripIndent().trim())
+
+            booleanParam('SQUASH_ON_COMPLETE', true, '''
+ワークフロー完了時にコミットをスカッシュする
+            '''.stripIndent().trim())
+
+            // ========================================
+            // Git 設定
+            // ========================================
+            stringParam('GIT_COMMIT_USER_NAME', 'AI Workflow Bot', '''
+Git コミットユーザー名
+            '''.stripIndent().trim())
+
+            stringParam('GIT_COMMIT_USER_EMAIL', 'ai-workflow@example.com', '''
+Git コミットメールアドレス
+            '''.stripIndent().trim())
+
+            // ========================================
+            // AWS 認証情報（Infrastructure as Code 用）
+            // ========================================
+            stringParam('AWS_ACCESS_KEY_ID', '', '''
+AWS アクセスキー ID（任意）
+Infrastructure as Code実行時に必要
+            '''.stripIndent().trim())
+
+            nonStoredPasswordParam('AWS_SECRET_ACCESS_KEY', '''
+AWS シークレットアクセスキー（任意）
+Infrastructure as Code実行時に必要
+            '''.stripIndent().trim())
+
+            nonStoredPasswordParam('AWS_SESSION_TOKEN', '''
+AWS セッショントークン（任意）
+一時的な認証情報を使用する場合
+            '''.stripIndent().trim())
+
+            // ========================================
+            // APIキー設定
+            // ========================================
+            nonStoredPasswordParam('GITHUB_TOKEN', '''
+GitHub Personal Access Token（任意）
+GitHub API呼び出しに使用されます
+            '''.stripIndent().trim())
+
+            nonStoredPasswordParam('OPENAI_API_KEY', '''
+OpenAI API キー（任意）
+Codex実行モードで使用されます
+            '''.stripIndent().trim())
+
+            nonStoredPasswordParam('CODEX_API_KEY', '''
+Codex API キー（任意）
+OPENAI_API_KEYの代替として使用可能
+            '''.stripIndent().trim())
+
+            nonStoredPasswordParam('CLAUDE_CODE_OAUTH_TOKEN', '''
+Claude Code OAuth トークン（任意）
+Claude実行モードで使用されます
+            '''.stripIndent().trim())
+
+            nonStoredPasswordParam('CLAUDE_CODE_API_KEY', '''
+Claude Code API キー（任意）
+Claude実行モードで使用されます
+            '''.stripIndent().trim())
+
+            nonStoredPasswordParam('ANTHROPIC_API_KEY', '''
+Anthropic API キー（任意）
+Claude実行モードで使用されます
+            '''.stripIndent().trim())
+
+            // ========================================
+            // その他
+            // ========================================
+            stringParam('COST_LIMIT_USD', '5.0', '''
+ワークフローあたりのコスト上限（USD）
+            '''.stripIndent().trim())
+
+            choiceParam('LOG_LEVEL', ['INFO', 'DEBUG', 'WARNING', 'ERROR'], '''
+ログレベル
+- INFO: 一般的な情報
+- DEBUG: 詳細ログ（デバッグ用）
+- WARNING / ERROR: 警告 / エラーのみ
+            '''.stripIndent().trim())
+        }
+
+        // ログローテーション
+        logRotator {
+            numToKeep(30)
+            daysToKeep(90)
+        }
+
+        // パイプライン定義
+        definition {
+            cpsScm {
+                scm {
+                    git {
+                        remote {
+                            url('https://github.com/tielec/ai-workflow-agent.git')
+                            credentials('github-token')
+                        }
+                        branch(gitBranch)
+                    }
+                }
+                scriptPath('Jenkinsfile')
+            }
+        }
+
+        // 環境変数（EXECUTION_MODEを固定値として設定）
+        environmentVariables {
+            env('EXECUTION_MODE', 'single_phase')
+            env('WORKFLOW_VERSION', '0.2.0')
+        }
+
+        // プロパティ
+        properties {
+            disableConcurrentBuilds()
+        }
+
+        // ジョブの無効化状態
+        disabled(false)
+    }
+}
+
+// 汎用フォルダ用ジョブを作成
+genericFolders.each { folder ->
+    createJob(
+        "AI_Workflow/${folder.name}/${jobConfig.name}",
+        "フォルダ: ${folder.displayName}\nブランチ: ${folder.branch}",
+        folder.branch
+    )
+}

--- a/jenkins/jobs/dsl/folders.groovy
+++ b/jenkins/jobs/dsl/folders.groovy
@@ -1,0 +1,172 @@
+// Jenkinsfileから渡されたフォルダ設定を取得
+def folderConfig = binding.hasVariable('jenkinsFoldersConfig') ?
+    binding.getVariable('jenkinsFoldersConfig') :
+    [:]
+
+if (!folderConfig) {
+    error("Folder configuration not found. Please ensure jenkinsFoldersConfig is passed from Jenkinsfile.")
+}
+
+println "=== Starting folder creation ==="
+
+// 作成済みフォルダを追跡（重複作成を防ぐ）
+def createdFolders = [] as Set
+
+// メイン処理
+
+// 1. 通常のフォルダを作成（パスでソートして親から順に作成）
+if (folderConfig.folders) {
+    println "\n=== Creating static folders ==="
+    // フォルダを階層順（浅い→深い）でソートし、同じ階層内では名前順にする
+    // これにより親フォルダが子フォルダより先に作成されることを保証する
+    def sortedFolders = folderConfig.folders.sort { a, b ->
+        def aDepth = a.path.count('/')
+        def bDepth = b.path.count('/')
+
+        // まず階層の深さで比較
+        if (aDepth != bDepth) {
+            return aDepth - bDepth  // 浅い階層を先に
+        }
+
+        // 同じ階層の場合は名前順
+        return a.path.compareTo(b.path)
+    }
+
+    sortedFolders.each { folderDef ->
+        def fullPath = folderDef.path
+
+        // パスから親フォルダを作成
+        def parts = fullPath.split('/')
+        def currentPath = ''
+
+        parts.eachWithIndex { part, index ->
+            currentPath = currentPath ? "${currentPath}/${part}" : part
+
+            // 最後の要素以外は親フォルダとして作成
+            if (index < parts.size() - 1) {
+                if (!createdFolders.contains(currentPath)) {
+                    folder(currentPath) {
+                        displayName(part)
+                        description("Auto-generated parent folder")
+                    }
+                    createdFolders.add(currentPath)
+                }
+            }
+        }
+
+        // フォルダを作成
+        if (!createdFolders.contains(fullPath)) {
+            folder(fullPath) {
+                displayName(folderDef.displayName ?: folderDef.path.split('/').last())
+                if (folderDef.description) {
+                    description(folderDef.description.stripIndent().trim())
+                }
+            }
+            createdFolders.add(fullPath)
+            println "Created folder: ${fullPath}"
+        }
+    }
+}
+
+// 2. 動的フォルダを作成
+if (folderConfig.dynamic_folders) {
+    println "\n=== Creating dynamic folders ==="
+
+    folderConfig.dynamic_folders.each { dynamicRule ->
+        if (dynamicRule.source == 'jenkins-managed-repositories' &&
+            binding.hasVariable('jenkinsManagedRepositories')) {
+
+            def repositories = binding.getVariable('jenkinsManagedRepositories')
+            def template = dynamicRule.template
+
+            println "Creating dynamic folders in: ${dynamicRule.parent_path}"
+
+            repositories.each { name, repo ->
+                def subfolderPath = "${dynamicRule.parent_path}/${template.path_suffix.replace('{name}', name)}"
+                def folderDisplayName = template.displayName.replace('{name}', name)
+                def folderDescription = template.description.replace('{name}', name)
+
+                // 親フォルダが存在することを確認
+                def parentParts = subfolderPath.split('/')
+                def parentPath = ''
+
+                parentParts.eachWithIndex { part, index ->
+                    parentPath = parentPath ? "${parentPath}/${part}" : part
+
+                    // 最後の要素以外は親フォルダとして作成
+                    if (index < parentParts.size() - 1) {
+                        if (!createdFolders.contains(parentPath)) {
+                            folder(parentPath) {
+                                displayName(part)
+                                description("Auto-generated parent folder")
+                            }
+                            createdFolders.add(parentPath)
+                        }
+                    }
+                }
+
+                // 動的フォルダを作成
+                folder(subfolderPath) {
+                    displayName(folderDisplayName)
+                    description(folderDescription.stripIndent().trim())
+                }
+                createdFolders.add(subfolderPath)
+                println "Created dynamic folder: ${subfolderPath}"
+            }
+        }
+        // Pulumiプロジェクト用の動的フォルダ作成を追加
+        if (dynamicRule.source == 'pulumi-projects' &&
+            binding.hasVariable('pulumi_projects')) {
+
+            def pulumiProjects = binding.getVariable('pulumi_projects')
+            def template = dynamicRule.template
+
+            println "Creating Pulumi project folders in: ${dynamicRule.parent_path}"
+
+            pulumiProjects.each { repoKey, repoConfig ->
+                def subfolderPath = "${dynamicRule.parent_path}/${template.path_suffix.replace('{repo_name}', repoConfig.repo_name)}"
+                def folderDisplayName = template.displayName.replace('{repo_name}', repoConfig.repo_name)
+                def folderDescription = template.description
+                    .replace('{repo_name}', repoConfig.repo_name)
+                    .replace('{display_name}', repoConfig.display_name ?: repoConfig.repo_name)
+
+                // プロジェクトパスの置換（最初のプロジェクトのパスを使用）
+                if (repoConfig.projects && repoConfig.projects.size() > 0) {
+                    def firstProject = repoConfig.projects.values().first()
+                    folderDescription = folderDescription.replace('{project_path}', firstProject.project_path)
+                }
+
+                // 親フォルダが存在することを確認
+                def parentParts = subfolderPath.split('/')
+                def parentPath = ''
+
+                parentParts.eachWithIndex { part, index ->
+                    parentPath = parentPath ? "${parentPath}/${part}" : part
+
+                    // 最後の要素以外は親フォルダとして作成
+                    if (index < parentParts.size() - 1) {
+                        if (!createdFolders.contains(parentPath)) {
+                            folder(parentPath) {
+                                displayName(part)
+                                description("Auto-generated parent folder")
+                            }
+                            createdFolders.add(parentPath)
+                        }
+                    }
+                }
+
+                // 動的フォルダを作成
+                folder(subfolderPath) {
+                    displayName(folderDisplayName)
+                    description(folderDescription.stripIndent().trim())
+                }
+                createdFolders.add(subfolderPath)
+                println "Created Pulumi project folder: ${subfolderPath}"
+            }
+        }
+    }
+}
+
+// 処理完了メッセージ
+println "\n=== Folder creation completed ==="
+println "Total folders created: ${createdFolders.size()}"

--- a/jenkins/jobs/pipeline/_seed/ai-workflow-job-creator/Jenkinsfile
+++ b/jenkins/jobs/pipeline/_seed/ai-workflow-job-creator/Jenkinsfile
@@ -1,0 +1,141 @@
+pipeline {
+    agent {
+        label 'built-in'
+    }
+
+    environment {
+        JOB_CONFIG_PATH = 'jenkins/jobs/pipeline/_seed/ai-workflow-job-creator/job-config.yaml'
+        FOLDER_CONFIG_PATH = 'jenkins/jobs/pipeline/_seed/ai-workflow-job-creator/folder-config.yaml'
+        FOLDERS_DSL_PATH = 'jenkins/jobs/dsl/folders.groovy'
+    }
+
+    stages {
+        stage('Validate Configuration') {
+            steps {
+                script {
+                    echo "=== Starting configuration validation ==="
+
+                    // 設定ファイルの存在チェック
+                    if (!fileExists(env.JOB_CONFIG_PATH)) {
+                        error("Job configuration file not found: ${env.JOB_CONFIG_PATH}")
+                    }
+                    echo "✓ Job configuration file found: ${env.JOB_CONFIG_PATH}"
+
+                    if (!fileExists(env.FOLDER_CONFIG_PATH)) {
+                        error("Folder configuration file not found: ${env.FOLDER_CONFIG_PATH}")
+                    }
+                    echo "✓ Folder configuration file found: ${env.FOLDER_CONFIG_PATH}"
+
+                    if (!fileExists(env.FOLDERS_DSL_PATH)) {
+                        error("Folders DSL file not found: ${env.FOLDERS_DSL_PATH}")
+                    }
+                    echo "✓ Folders DSL file found: ${env.FOLDERS_DSL_PATH}"
+
+                    // ジョブ設定の検証（AI Workflow関連のみ）
+                    def jobConfig = readYaml file: env.JOB_CONFIG_PATH
+                    def aiWorkflowJobs = jobConfig['jenkins-jobs'].findAll { jobKey, jobDef ->
+                        jobKey.startsWith('ai_workflow_')
+                    }
+
+                    echo "\n=== Validating ${aiWorkflowJobs.size()} AI Workflow job configurations ==="
+
+                    def validationErrors = []
+                    aiWorkflowJobs.each { jobKey, jobDef ->
+                        // dslfileの存在チェック
+                        if (jobDef.dslfile && !fileExists(jobDef.dslfile)) {
+                            validationErrors.add("Job '${jobKey}': DSL file not found - ${jobDef.dslfile}")
+                        }
+
+                        // jenkinsfileの存在チェック（skipJenkinsfileValidation: true の場合はスキップ）
+                        if (jobDef.jenkinsfile && !jobDef.skipJenkinsfileValidation && !fileExists(jobDef.jenkinsfile)) {
+                            validationErrors.add("Job '${jobKey}': Jenkinsfile not found - ${jobDef.jenkinsfile}")
+                        }
+                    }
+
+                    if (validationErrors.size() > 0) {
+                        echo "\n=== Validation Errors ==="
+                        validationErrors.each { error ->
+                            echo "  ✗ ${error}"
+                        }
+                        error("Configuration validation failed with ${validationErrors.size()} errors")
+                    }
+
+                    echo "\n✅ All validations passed successfully!"
+                }
+            }
+        }
+
+        stage('Create Folder Structure and Jobs') {
+            steps {
+                script {
+                    // 設定ファイルを読み込む
+                    def jobConfig = readYaml file: env.JOB_CONFIG_PATH
+                    def folderConfig = readYaml file: env.FOLDER_CONFIG_PATH
+
+                    // AI Workflow関連ジョブのみを抽出
+                    def aiWorkflowJobs = jobConfig['jenkins-jobs'].findAll { jobKey, jobDef ->
+                        jobKey.startsWith('ai_workflow_')
+                    }
+
+                    def dslFiles = []
+
+                    // folders.groovyを最初に実行（フォルダ構造を作成）
+                    dslFiles.add(env.FOLDERS_DSL_PATH)
+
+                    // AI Workflow関連ジョブのDSLファイルを追加
+                    aiWorkflowJobs.each { jobKey, jobDef ->
+                        if (jobDef.dslfile) {
+                            dslFiles.add(jobDef.dslfile)
+                        }
+                    }
+
+                    echo "=== Job DSL Execution Plan ==="
+                    echo "Total DSL files: ${dslFiles.size()}"
+                    echo "AI Workflow jobs to create: ${aiWorkflowJobs.size()}"
+                    echo "AI Workflow folders: ${folderConfig.folders?.findAll { it.path.startsWith('AI_Workflow') }?.size() ?: 0}"
+
+                    // 追加のパラメータを準備
+                    def additionalParams = [
+                        // ジョブ設定（AI Workflow関連のみ）
+                        jenkinsJobsConfig: aiWorkflowJobs,
+                        // フォルダ設定（全体）
+                        jenkinsFoldersConfig: folderConfig
+                    ]
+
+                    // 共通設定が存在する場合は追加
+                    if (jobConfig['common-settings']) {
+                        additionalParams['commonSettings'] = jobConfig['common-settings']
+                    }
+
+                    echo "\n=== Executing Job DSL ==="
+                    echo "⚠️ Note: Jobs, views, and config files no longer defined in DSL will be automatically deleted."
+
+                    // Job DSLを実行
+                    jobDsl(
+                        targets: dslFiles.join('\n'),
+                        lookupStrategy: 'SEED_JOB',
+                        additionalParameters: additionalParams,
+                        removedJobAction: 'DELETE',
+                        removedViewAction: 'DELETE',
+                        removedConfigFilesAction: 'DELETE'
+                    )
+
+                    echo "\n✅ Job DSL execution completed!"
+                    echo "Note: AI Workflow items no longer defined in DSL have been automatically removed."
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            cleanWs()
+        }
+        success {
+            echo "✅ AI Workflow seed job completed successfully!"
+        }
+        failure {
+            echo "❌ AI Workflow seed job failed. Please check the logs for details."
+        }
+    }
+}

--- a/jenkins/jobs/pipeline/_seed/ai-workflow-job-creator/folder-config.yaml
+++ b/jenkins/jobs/pipeline/_seed/ai-workflow-job-creator/folder-config.yaml
@@ -1,0 +1,197 @@
+# Jenkins フォルダ構造設定ファイル - AI Workflow専用
+
+# フォルダ定義（フラット構造）
+folders:
+  # AI駆動開発フォルダ（親フォルダ）
+  - path: "AI_Workflow"
+    displayName: "50. [AI] AI駆動開発"
+    description: |
+      このフォルダーには、AI駆動開発自動化ワークフローのジョブが含まれています。
+
+      ### 概要
+      GitHub IssueからPR作成まで、Claude AIが自動的に開発プロセスを実行します。
+      実行モードごとにジョブが分割され、リポジトリ別に整理されています。
+
+      ### ジョブ構成
+      各リポジトリ配下に以下のジョブが配置されます：
+      * **all_phases** - 全フェーズ一括実行（planning → evaluation）
+      * **preset** - プリセット実行（quick-fix, implementation等）
+      * **single_phase** - 単一フェーズ実行
+      * **rollback** - フェーズ差し戻し実行
+      * **auto_issue** - AIによる自動Issue作成
+
+      ### パラメータ削減効果
+      実行モードごとの分割により、パラメータ数を24個 → 8〜15個に削減しました。
+
+      ### 主な機能
+      * **自動要件定義** - GitHub Issueから要件定義書を生成
+      * **自動設計** - 詳細設計書とアーキテクチャドキュメントを生成
+      * **自動テストシナリオ** - BDD形式のテストシナリオを生成
+      * **自動実装** - コードの自動生成と既存コードの拡張
+      * **自動テスト** - テストの実行と結果検証
+      * **自動ドキュメント** - README、APIドキュメントを生成
+
+      ### 必要な認証情報
+      * **claude-api-key**: Claude API キー（Jenkinsクレデンシャル）
+      * **github-token**: GitHub Token（Jenkinsクレデンシャル）
+
+  # Issue #470: AI Workflow用フォルダをリポジトリ非依存の汎用フォルダのみに変更
+  # 更新日: 2025-01-17
+  # URL: https://github.com/tielec/infrastructure-as-code/issues/470
+  #
+  # 構成:
+  # - Develop: 1フォルダ（最新機能のテスト用）
+  # - Stable: 9フォルダ（安定バージョン、並行実行可能）
+
+  # AI Workflow - Develop用フォルダ
+  - path: "AI_Workflow/develop"
+    displayName: "AI Workflow Executor - Develop"
+    description: |
+      developブランチ用のワークフロー実行環境
+
+      ### 用途
+      - ai-workflow-agentの**最新バージョン**（developブランチ）を使用
+      - 新機能のテスト、実験的な利用
+
+      ### 対象ブランチ
+      - ai-workflow-agent: **develop**
+
+      ### 注意事項
+      - 開発中の機能のため、動作が不安定な場合があります
+      - 安定した動作が必要な場合はStableフォルダを使用してください
+
+  # AI Workflow - Stable用フォルダ（1〜9）
+  - path: "AI_Workflow/stable-1"
+    displayName: "AI Workflow Executor - Stable 1"
+    description: |
+      mainブランチ用のワークフロー実行環境（Stable 1）
+
+      ### 用途
+      - ai-workflow-agentの**安定バージョン**（mainブランチ）を使用
+      - 本番環境での利用、安定した動作が求められる場合
+
+      ### 対象ブランチ
+      - ai-workflow-agent: **main**
+
+      ### 並行利用について
+      - Stableフォルダは9つあり、複数のワークフローを同時実行可能です
+
+  - path: "AI_Workflow/stable-2"
+    displayName: "AI Workflow Executor - Stable 2"
+    description: |
+      mainブランチ用のワークフロー実行環境（Stable 2）
+
+      ### 用途
+      - ai-workflow-agentの**安定バージョン**（mainブランチ）を使用
+      - 本番環境での利用、安定した動作が求められる場合
+
+      ### 対象ブランチ
+      - ai-workflow-agent: **main**
+
+      ### 並行利用について
+      - Stableフォルダは9つあり、複数のワークフローを同時実行可能です
+
+  - path: "AI_Workflow/stable-3"
+    displayName: "AI Workflow Executor - Stable 3"
+    description: |
+      mainブランチ用のワークフロー実行環境（Stable 3）
+
+      ### 用途
+      - ai-workflow-agentの**安定バージョン**（mainブランチ）を使用
+      - 本番環境での利用、安定した動作が求められる場合
+
+      ### 対象ブランチ
+      - ai-workflow-agent: **main**
+
+      ### 並行利用について
+      - Stableフォルダは9つあり、複数のワークフローを同時実行可能です
+
+  - path: "AI_Workflow/stable-4"
+    displayName: "AI Workflow Executor - Stable 4"
+    description: |
+      mainブランチ用のワークフロー実行環境（Stable 4）
+
+      ### 用途
+      - ai-workflow-agentの**安定バージョン**（mainブランチ）を使用
+      - 本番環境での利用、安定した動作が求められる場合
+
+      ### 対象ブランチ
+      - ai-workflow-agent: **main**
+
+      ### 並行利用について
+      - Stableフォルダは9つあり、複数のワークフローを同時実行可能です
+
+  - path: "AI_Workflow/stable-5"
+    displayName: "AI Workflow Executor - Stable 5"
+    description: |
+      mainブランチ用のワークフロー実行環境（Stable 5）
+
+      ### 用途
+      - ai-workflow-agentの**安定バージョン**（mainブランチ）を使用
+      - 本番環境での利用、安定した動作が求められる場合
+
+      ### 対象ブランチ
+      - ai-workflow-agent: **main**
+
+      ### 並行利用について
+      - Stableフォルダは9つあり、複数のワークフローを同時実行可能です
+
+  - path: "AI_Workflow/stable-6"
+    displayName: "AI Workflow Executor - Stable 6"
+    description: |
+      mainブランチ用のワークフロー実行環境（Stable 6）
+
+      ### 用途
+      - ai-workflow-agentの**安定バージョン**（mainブランチ）を使用
+      - 本番環境での利用、安定した動作が求められる場合
+
+      ### 対象ブランチ
+      - ai-workflow-agent: **main**
+
+      ### 並行利用について
+      - Stableフォルダは9つあり、複数のワークフローを同時実行可能です
+
+  - path: "AI_Workflow/stable-7"
+    displayName: "AI Workflow Executor - Stable 7"
+    description: |
+      mainブランチ用のワークフロー実行環境（Stable 7）
+
+      ### 用途
+      - ai-workflow-agentの**安定バージョン**（mainブランチ）を使用
+      - 本番環境での利用、安定した動作が求められる場合
+
+      ### 対象ブランチ
+      - ai-workflow-agent: **main**
+
+      ### 並行利用について
+      - Stableフォルダは9つあり、複数のワークフローを同時実行可能です
+
+  - path: "AI_Workflow/stable-8"
+    displayName: "AI Workflow Executor - Stable 8"
+    description: |
+      mainブランチ用のワークフロー実行環境（Stable 8）
+
+      ### 用途
+      - ai-workflow-agentの**安定バージョン**（mainブランチ）を使用
+      - 本番環境での利用、安定した動作が求められる場合
+
+      ### 対象ブランチ
+      - ai-workflow-agent: **main**
+
+      ### 並行利用について
+      - Stableフォルダは9つあり、複数のワークフローを同時実行可能です
+
+  - path: "AI_Workflow/stable-9"
+    displayName: "AI Workflow Executor - Stable 9"
+    description: |
+      mainブランチ用のワークフロー実行環境（Stable 9）
+
+      ### 用途
+      - ai-workflow-agentの**安定バージョン**（mainブランチ）を使用
+      - 本番環境での利用、安定した動作が求められる場合
+
+      ### 対象ブランチ
+      - ai-workflow-agent: **main**
+
+      ### 並行利用について
+      - Stableフォルダは9つあり、複数のワークフローを同時実行可能です

--- a/jenkins/jobs/pipeline/_seed/ai-workflow-job-creator/job-config.yaml
+++ b/jenkins/jobs/pipeline/_seed/ai-workflow-job-creator/job-config.yaml
@@ -1,0 +1,49 @@
+# JobDSL設定ファイル - AI Workflow専用
+
+# 共通設定
+common-settings:
+  # Jenkinsパイプラインリポジトリ設定
+  jenkins-pipeline-repo:
+    url: 'https://github.com/tielec/ai-workflow-agent'
+    credentials: 'github-app-credentials'
+    branch: '*/main'
+
+# AI Workflow専用ジョブ定義
+jenkins-jobs:
+  # AI Workflow Jobs（新しいジョブ構成）
+  # 注意: これらのジョブはai-workflow-agentリポジトリのJenkinsfileを使用するため
+  # skipJenkinsfileValidation: true を設定してローカル存在チェックをスキップ
+  ai_workflow_all_phases_job:
+    name: 'all_phases'
+    displayName: 'All Phases Execution'
+    dslfile: jenkins/jobs/dsl/ai-workflow/ai_workflow_all_phases_job.groovy
+    jenkinsfile: Jenkinsfile
+    skipJenkinsfileValidation: true
+
+  ai_workflow_preset_job:
+    name: 'preset'
+    displayName: 'Preset Execution'
+    dslfile: jenkins/jobs/dsl/ai-workflow/ai_workflow_preset_job.groovy
+    jenkinsfile: Jenkinsfile
+    skipJenkinsfileValidation: true
+
+  ai_workflow_single_phase_job:
+    name: 'single_phase'
+    displayName: 'Single Phase Execution'
+    dslfile: jenkins/jobs/dsl/ai-workflow/ai_workflow_single_phase_job.groovy
+    jenkinsfile: Jenkinsfile
+    skipJenkinsfileValidation: true
+
+  ai_workflow_rollback_job:
+    name: 'rollback'
+    displayName: 'Rollback Execution'
+    dslfile: jenkins/jobs/dsl/ai-workflow/ai_workflow_rollback_job.groovy
+    jenkinsfile: Jenkinsfile
+    skipJenkinsfileValidation: true
+
+  ai_workflow_auto_issue_job:
+    name: 'auto_issue'
+    displayName: 'Auto Issue Creation'
+    dslfile: jenkins/jobs/dsl/ai-workflow/ai_workflow_auto_issue_job.groovy
+    jenkinsfile: Jenkinsfile
+    skipJenkinsfileValidation: true


### PR DESCRIPTION
## Summary
- AI Workflow関連のJenkins Job定義を`infrastructure-as-code`リポジトリから本リポジトリに移行
- リポジトリ間の相互依存を解消し、AI Workflowに関するコードを一元管理

## 変更内容
### 追加ファイル
- `jenkins/README.md` - Jenkins Job定義の説明
- `jenkins/jobs/pipeline/_seed/ai-workflow-job-creator/` - シードジョブ定義一式
  - `Jenkinsfile`
  - `folder-config.yaml`
  - `job-config.yaml`
- `jenkins/jobs/dsl/folders.groovy` - フォルダ作成DSL
- `jenkins/jobs/dsl/ai-workflow/` - Job DSLファイル
  - `ai_workflow_all_phases_job.groovy`
  - `ai_workflow_preset_job.groovy`
  - `ai_workflow_single_phase_job.groovy`
  - `ai_workflow_rollback_job.groovy`
  - `ai_workflow_auto_issue_job.groovy`
  - `TEST_PLAN.md`

## 関連Issue
- Closes #230
- Related: https://github.com/tielec/infrastructure-as-code/issues/481

## Test plan
- [ ] Jenkins環境でシードジョブを実行し、ジョブが正常に生成されることを確認
- [ ] 生成されたジョブのパラメータが正しく設定されていることを確認
- [ ] DRY_RUN=trueでジョブを実行し、エラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)