### PR TITLE
fix(base-phase): REPOS_ROOT設定時にgetAgentWorkingDirectory()が正しいパスを返すよう修正

### DIFF
--- a/src/phases/base-phase.ts
+++ b/src/phases/base-phase.ts
@@ -94,6 +94,18 @@ export abstract class BasePhase {
   }
 
   protected getAgentWorkingDirectory(): string {
+    // Issue #245: REPOS_ROOT が設定されている場合は動的にパスを解決
+    // PR #235 の execute.ts と同様のロジックで、WORKSPACE と REPOS_ROOT の分離に対応
+    const reposRoot = config.getReposRoot();
+    if (reposRoot && this.metadata.data.target_repository?.repo) {
+      const repoName = this.metadata.data.target_repository.repo;
+      const reposRootPath = path.join(reposRoot, repoName);
+      if (fs.existsSync(reposRootPath)) {
+        logger.debug(`Using REPOS_ROOT path for agent working directory: ${reposRootPath}`);
+        return reposRootPath;
+      }
+    }
+
     try {
       return this.getActiveAgent().getWorkingDirectory();
     } catch {


### PR DESCRIPTION
## Summary

- `getAgentWorkingDirectory()` で REPOS_ROOT 環境変数を考慮するよう修正
- REPOS_ROOT 設定時は `REPOS_ROOT/repo-name` を動的に解決
- PR #235 の `execute.ts` と同様のロジックで、WORKSPACE と REPOS_ROOT の分離に対応
- `ContextBuilder` が正しいパスで相対パスを計算可能に

## 関連 Issue

Closes #245

## 問題

preset 実行時に、`ContextBuilder.getAgentFileReference()` が WORKSPACE パスを基準に相対パス計算するため、REPOS_ROOT にあるファイル（planning.md 等）を参照できずレビューが失敗していた。

```
[WARN] Failed to resolve relative path for planning document: /tmp/jenkins-f07f1bf6/workspace/AI_Workflow/develop/preset/.ai-workflow/issue-243/00_planning/output/planning.md
[WARN] Phase requirements: Review failed: Agent が requirements.md を参照できません。
```

## 修正内容

`base-phase.ts` の `getAgentWorkingDirectory()` で、REPOS_ROOT 環境変数が設定されている場合は REPOS_ROOT/repo-name を返すよう修正：

```typescript
protected getAgentWorkingDirectory(): string {
  // Issue #245: REPOS_ROOT が設定されている場合は動的にパスを解決
  const reposRoot = config.getReposRoot();
  if (reposRoot && this.metadata.data.target_repository?.repo) {
    const repoName = this.metadata.data.target_repository.repo;
    const reposRootPath = path.join(reposRoot, repoName);
    if (fs.existsSync(reposRootPath)) {
      return reposRootPath;
    }
  }
  // ... 従来のフォールバック処理
}
```

## Test plan

- [ ] ビルドが成功することを確認
- [ ] preset 実行時に Planning Document が正しく参照できる
- [ ] ローカル実行（REPOS_ROOT 未設定）時も正常に動作する
- [ ] 既存の全フェーズ実行でも正常に動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)