### PR TITLE
fix(agent): Pass REPOS_ROOT working directory to agent executor

### DIFF
--- a/src/phases/base-phase.ts
+++ b/src/phases/base-phase.ts
@@ -143,6 +143,7 @@ export abstract class BasePhase {
     this.reviewCycleManager = new ReviewCycleManager(this.metadata, this.phaseName);
 
     // AgentExecutor は遅延初期化（codex/claude が設定されている場合のみ）
+    // Issue #264: getAgentWorkingDirectory 関数を渡して REPOS_ROOT 対応
     if (this.codex || this.claude) {
       this.agentExecutor = new AgentExecutor(
         this.codex,
@@ -150,6 +151,7 @@ export abstract class BasePhase {
         this.metadata,
         this.phaseName,
         this.workingDir,
+        () => this.getAgentWorkingDirectory(),
       );
     }
 


### PR DESCRIPTION
## Summary

- Fix agent writing files to WORKSPACE instead of REPOS_ROOT in Jenkins environment
- Add `getAgentWorkingDirectoryFn` parameter to `AgentExecutor` constructor
- Pass `getAgentWorkingDirectory()` from `BasePhase` to `AgentExecutor`

Closes #264

## Problem

In Jenkins environment, WORKSPACE and REPOS_ROOT are different paths:
- WORKSPACE: `/tmp/jenkins-.../workspace/AI_Workflow/develop/all_phases`
- REPOS_ROOT: `/tmp/ai-workflow-repos-.../{repo}`

The agent was always using WORKSPACE path when executing tasks, causing output files to be written to the wrong location.

## Changes

### `src/phases/core/agent-executor.ts`

- Add `getAgentWorkingDirectoryFn` as optional constructor parameter
- Use `getAgentWorkingDirectoryFn?.() ?? this.workingDir` in `runAgentTask()`
- Add debug logging for agent working directory

### `src/phases/base-phase.ts`

- Pass `() => this.getAgentWorkingDirectory()` to `AgentExecutor` constructor
- This reuses the existing REPOS_ROOT-aware logic from Issue #245

## How it works

```
Before (Issue #264):
  AgentExecutor.runAgentTask()
    └─ agent.executeTask({ workingDirectory: this.workingDir })  // WORKSPACE path
    
After:
  AgentExecutor.runAgentTask()
    └─ agent.executeTask({ workingDirectory: getAgentWorkingDirectoryFn() })  // REPOS_ROOT path
```

## Test Plan

- [ ] Run workflow in Jenkins with REPOS_ROOT set
- [ ] Verify agent writes files to REPOS_ROOT path
- [ ] Verify fallback mechanism is no longer triggered (agent writes to correct location)
- [ ] Verify local development (without REPOS_ROOT) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)