### PR TITLE
fix(base-phase): Use REPOS_ROOT for output directories when available

### DIFF
--- a/src/phases/base-phase.ts
+++ b/src/phases/base-phase.ts
@@ -113,6 +113,33 @@ export abstract class BasePhase {
     }
   }
 
+  /**
+   * Issue #274: ワークフローディレクトリのベースパスを解決
+   *
+   * REPOS_ROOT が設定されている場合は、対象リポジトリの .ai-workflow ディレクトリを使用。
+   * Jenkins環境ではWORKSPACEとREPOS_ROOTが分離されているため、
+   * 成果物ファイルは REPOS_ROOT 配下に保存する必要がある。
+   *
+   * @returns ワークフローのベースディレクトリ（例: /tmp/repos/repo-name/.ai-workflow/issue-123）
+   */
+  private resolveWorkflowBaseDir(): string {
+    const reposRoot = config.getReposRoot();
+    const repoName = this.metadata.data.target_repository?.repo;
+    const issueNumber = this.metadata.data.issue_number;
+
+    if (reposRoot && repoName && issueNumber) {
+      const reposRootPath = path.join(reposRoot, repoName);
+      if (fs.existsSync(reposRootPath)) {
+        const workflowDir = path.join(reposRootPath, '.ai-workflow', `issue-${issueNumber}`);
+        logger.debug(`Using REPOS_ROOT path for workflow directory: ${workflowDir}`);
+        return workflowDir;
+      }
+    }
+
+    // フォールバック: metadata.workflowDir を使用
+    return this.metadata.workflowDir;
+  }
+
   constructor(params: BasePhaseConstructorParams) {
     this.phaseName = params.phaseName;
     this.workingDir = params.workingDir;
@@ -129,7 +156,9 @@ export abstract class BasePhase {
       : { enabled: false, provider: 'auto' };
 
     const phaseNumber = this.getPhaseNumber(this.phaseName);
-    this.phaseDir = path.join(this.metadata.workflowDir, `${phaseNumber}_${this.phaseName}`);
+    // Issue #274: REPOS_ROOT が設定されている場合は動的にパスを解決
+    const workflowBaseDir = this.resolveWorkflowBaseDir();
+    this.phaseDir = path.join(workflowBaseDir, `${phaseNumber}_${this.phaseName}`);
     this.outputDir = path.join(this.phaseDir, 'output');
     this.executeDir = path.join(this.phaseDir, 'execute');
     this.reviewDir = path.join(this.phaseDir, 'review');


### PR DESCRIPTION
## Summary

- Issue #274: フォールバック機構等でWORKSPACEではなくREPOS_ROOTを使用するよう修正
- `resolveWorkflowBaseDir()` メソッドを追加し、REPOS_ROOT環境変数が設定されている場合は対象リポジトリの `.ai-workflow` ディレクトリを使用
- Jenkins環境でWORKSPACEとREPOS_ROOTが分離されている場合でも、成果物ファイルが正しいパスに保存されるように改善

## Test plan

- [ ] Jenkins環境でREPOS_ROOTが設定されている場合、outputDirがREPOS_ROOT配下になることを確認
- [ ] REPOS_ROOTが設定されていない場合（ローカル環境）、従来通りmetadata.workflowDirを使用することを確認
- [ ] フォールバック機構が正しくファイルを見つけられることを確認

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)