### PR TITLE
fix(squash-manager): Ensure git config before creating squash commit

### DIFF
--- a/src/core/git/commit-manager.ts
+++ b/src/core/git/commit-manager.ts
@@ -446,8 +446,10 @@ export class CommitManager {
 
   /**
    * Ensure git config (user.name and user.email)
+   *
+   * Note: Made public for use by SquashManager during finalize command.
    */
-  private async ensureGitConfig(): Promise<void> {
+  public async ensureGitConfig(): Promise<void> {
     const gitConfig = await this.git.listConfig();
     const userNameFromConfig = gitConfig.all['user.name'] as string | undefined;
     const userEmailFromConfig = gitConfig.all['user.email'] as string | undefined;

--- a/src/core/git/squash-manager.ts
+++ b/src/core/git/squash-manager.ts
@@ -261,6 +261,9 @@ export class SquashManager {
    */
   private async executeSquash(baseCommit: string, message: string): Promise<void> {
     try {
+      // 0. Git設定を確認（user.name, user.email）
+      await this.commitManager.ensureGitConfig();
+
       // 1. git reset --soft <base_commit>
       logger.info(`Resetting to ${baseCommit}...`);
       await this.git.reset(['--soft', baseCommit]);


### PR DESCRIPTION
In Jenkins environment, git user.name and user.email may not be configured, causing "Author identity unknown" error during commit.

Changes:
- Make ensureGitConfig() public in CommitManager
- Call ensureGitConfig() in SquashManager.executeSquash() before commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)