### PR TITLE
fix(finalize): Add commitWorkflowDeletion for deleted files

### DIFF
--- a/src/core/git-manager.ts
+++ b/src/core/git-manager.ts
@@ -222,4 +222,14 @@ export class GitManager {
     return this.squashManager;
   }
 
+  /**
+   * Issue #276: ワークフローディレクトリ削除をコミット
+   *
+   * finalize コマンドで .ai-workflow/issue-* ディレクトリ削除後に、
+   * 削除されたファイルをGitにコミットする。
+   */
+  public async commitWorkflowDeletion(issueNumber: number): Promise<CommitResult> {
+    return this.commitManager.commitWorkflowDeletion(issueNumber);
+  }
+
 }


### PR DESCRIPTION
The previous approach used commitCleanupLogs which filters out non-existent files. However, after cleanupWorkflowArtifacts() deletes the .ai-workflow/issue-* directory, we need to commit the deletion.

Changes:
- Add commitWorkflowDeletion() to CommitManager that:
  - Uses git status to find deleted files
  - Uses git add -A to stage deletions
  - Creates commit for the deleted workflow files
- Add facade method to GitManager
- Update executeStep2 in finalize.ts to use the new method

🤖 Generated with [Claude Code](https://claude.com/claude-code)