### PR TITLE
fix(phases): Fix REPOS_ROOT path resolution for context and commits

### DIFF
--- a/src/core/git/commit-manager.ts
+++ b/src/core/git/commit-manager.ts
@@ -166,6 +166,8 @@ export class CommitManager {
 
   /**
    * Issue #10: Commit step output files
+   * Issue #274: workingDir パラメータは後方互換性のために残すが、
+   *             内部では this.repoPath を使用（REPOS_ROOT 対応）
    */
   public async commitStepOutput(
     phaseName: PhaseName,
@@ -200,7 +202,8 @@ export class CommitManager {
     }
 
     // 2. Secret masking
-    const workflowDir = join(workingDir, '.ai-workflow', `issue-${issueNumber}`);
+    // Issue #274: workingDir の代わりに this.repoPath を使用（REPOS_ROOT 対応）
+    const workflowDir = join(this.repoPath, '.ai-workflow', `issue-${issueNumber}`);
     try {
       const maskingResult = await this.secretMasker.maskSecretsInWorkflowDir(workflowDir);
       if (maskingResult.filesProcessed > 0) {

--- a/src/phases/base-phase.ts
+++ b/src/phases/base-phase.ts
@@ -185,10 +185,12 @@ export abstract class BasePhase {
     }
 
     // 新規モジュールの初期化 (Issue #49)
+    // Issue #274: workflowBaseDir を渡して REPOS_ROOT 対応
     this.contextBuilder = new ContextBuilder(
       this.metadata,
       this.workingDir,
-      () => this.getAgentWorkingDirectory()
+      () => this.getAgentWorkingDirectory(),
+      workflowBaseDir
     );
     this.artifactCleaner = new ArtifactCleaner(this.metadata);
 


### PR DESCRIPTION
Issue #274: Multiple REPOS_ROOT-related fixes:

1. ContextBuilder:
   - Accept workflowBaseDir parameter from BasePhase
   - Use workflowBaseDir instead of metadata.workflowDir for output file paths
   - Remove redundant REPOS_ROOT resolution logic (now handled by BasePhase)

2. BasePhase:
   - Pass resolved workflowBaseDir to ContextBuilder constructor

3. CommitManager:
   - Use this.repoPath instead of workingDir parameter for secret masking
   - workingDir parameter kept for backward compatibility

These changes ensure that in Jenkins environment where WORKSPACE and REPOS_ROOT are separated, all file operations use the correct REPOS_ROOT path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)