### PR TITLE
Support Codex workspace auth injection

### DIFF
--- a/jenkins/jobs/dsl/ai-workflow/ai_workflow_all_phases_job.groovy
+++ b/jenkins/jobs/dsl/ai-workflow/ai_workflow_all_phases_job.groovy
@@ -148,6 +148,13 @@ Codex API キー（任意）
 OPENAI_API_KEYの代替として使用可能
             '''.stripIndent().trim())
 
+            textParam('CODEX_AUTH_JSON', '', '''
+Codex auth.json の内容（任意）
+
+Codex CLI 用の ~/.codex/auth.json を貼り付けます。ジョブ実行中のみ workspace/.codex/auth.json として展開され、完了後にクリーンアップされます。
+空欄の場合はファイルを作成しません。※ 入力内容はログに出力されません。
+            '''.stripIndent().trim())
+
             nonStoredPasswordParam('CLAUDE_CODE_OAUTH_TOKEN', '''
 Claude Code OAuth トークン（任意）
 Claude実行モードで使用されます

--- a/jenkins/jobs/dsl/ai-workflow/ai_workflow_auto_issue_job.groovy
+++ b/jenkins/jobs/dsl/ai-workflow/ai_workflow_auto_issue_job.groovy
@@ -122,6 +122,13 @@ Codex API キー（任意）
 OPENAI_API_KEYの代替として使用可能
             '''.stripIndent().trim())
 
+            textParam('CODEX_AUTH_JSON', '', '''
+Codex auth.json の内容（任意）
+
+Codex CLI 用の ~/.codex/auth.json を貼り付けます。ジョブ実行中のみ workspace/.codex/auth.json として展開され、完了後にクリーンアップされます。
+空欄の場合はファイルを作成しません。※ 入力内容はログに出力されません。
+            '''.stripIndent().trim())
+
             nonStoredPasswordParam('CLAUDE_CODE_OAUTH_TOKEN', '''
 Claude Code OAuth トークン（任意）
 Claude実行モードで使用されます

--- a/jenkins/jobs/dsl/ai-workflow/ai_workflow_finalize_job.groovy
+++ b/jenkins/jobs/dsl/ai-workflow/ai_workflow_finalize_job.groovy
@@ -169,6 +169,13 @@ Codex API キー（任意）
 OPENAI_API_KEYの代替として使用可能
             '''.stripIndent().trim())
 
+            textParam('CODEX_AUTH_JSON', '', '''
+Codex auth.json の内容（任意）
+
+Codex CLI 用の ~/.codex/auth.json を貼り付けます。ジョブ実行中のみ workspace/.codex/auth.json として展開され、完了後にクリーンアップされます。
+空欄の場合はファイルを作成しません。※ 入力内容はログに出力されません。
+            '''.stripIndent().trim())
+
             nonStoredPasswordParam('CLAUDE_CODE_OAUTH_TOKEN', '''
 Claude Code OAuth トークン（任意）
 Claude実行モードで使用されます

--- a/jenkins/jobs/dsl/ai-workflow/ai_workflow_preset_job.groovy
+++ b/jenkins/jobs/dsl/ai-workflow/ai_workflow_preset_job.groovy
@@ -166,6 +166,13 @@ Codex API キー（任意）
 OPENAI_API_KEYの代替として使用可能
             '''.stripIndent().trim())
 
+            textParam('CODEX_AUTH_JSON', '', '''
+Codex auth.json の内容（任意）
+
+Codex CLI 用の ~/.codex/auth.json を貼り付けます。ジョブ実行中のみ workspace/.codex/auth.json として展開され、完了後にクリーンアップされます。
+空欄の場合はファイルを作成しません。※ 入力内容はログに出力されません。
+            '''.stripIndent().trim())
+
             nonStoredPasswordParam('CLAUDE_CODE_OAUTH_TOKEN', '''
 Claude Code OAuth トークン（任意）
 Claude実行モードで使用されます

--- a/jenkins/jobs/dsl/ai-workflow/ai_workflow_rollback_job.groovy
+++ b/jenkins/jobs/dsl/ai-workflow/ai_workflow_rollback_job.groovy
@@ -174,6 +174,13 @@ Codex API キー（任意）
 OPENAI_API_KEYの代替として使用可能
             '''.stripIndent().trim())
 
+            textParam('CODEX_AUTH_JSON', '', '''
+Codex auth.json の内容（任意）
+
+Codex CLI 用の ~/.codex/auth.json を貼り付けます。ジョブ実行中のみ workspace/.codex/auth.json として展開され、完了後にクリーンアップされます。
+空欄の場合はファイルを作成しません。※ 入力内容はログに出力されません。
+            '''.stripIndent().trim())
+
             nonStoredPasswordParam('CLAUDE_CODE_OAUTH_TOKEN', '''
 Claude Code OAuth トークン（任意）
 Claude実行モードで使用されます

--- a/jenkins/jobs/dsl/ai-workflow/ai_workflow_single_phase_job.groovy
+++ b/jenkins/jobs/dsl/ai-workflow/ai_workflow_single_phase_job.groovy
@@ -154,6 +154,13 @@ Codex API キー（任意）
 OPENAI_API_KEYの代替として使用可能
             '''.stripIndent().trim())
 
+            textParam('CODEX_AUTH_JSON', '', '''
+Codex auth.json の内容（任意）
+
+Codex CLI 用の ~/.codex/auth.json を貼り付けます。ジョブ実行中のみ workspace/.codex/auth.json として展開され、完了後にクリーンアップされます。
+空欄の場合はファイルを作成しません。※ 入力内容はログに出力されません。
+            '''.stripIndent().trim())
+
             nonStoredPasswordParam('CLAUDE_CODE_OAUTH_TOKEN', '''
 Claude Code OAuth トークン（任意）
 Claude実行モードで使用されます

--- a/jenkins/jobs/pipeline/ai-workflow/all-phases/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/all-phases/Jenkinsfile
@@ -9,6 +9,7 @@
  * - AGENT_MODE: エージェントモード（デフォルト: auto）
  * - GITHUB_TOKEN: GitHub Personal Access Token（必須）
  * - CODEX_API_KEY: Codexエージェント用APIキー（オプション）
+ * - CODEX_AUTH_JSON: Codex ~/.codex/auth.json の内容（オプション）
  * - OPENAI_API_KEY: OpenAI API用キー（オプション）
  * - CLAUDE_CODE_OAUTH_TOKEN: Claude Codeエージェント用OAuthトークン（オプション）
  * - CLAUDE_CODE_API_KEY: Claude Codeエージェント用APIキー（オプション）
@@ -51,6 +52,7 @@ pipeline {
         WORKFLOW_DIR = '.'
         WORKFLOW_VERSION = '0.2.0'
         EXECUTION_MODE = 'all_phases'
+        CODEX_HOME = ''
 
         // ログ設定（CI環境ではカラーリング無効化）
         LOG_NO_COLOR = 'true'
@@ -100,6 +102,15 @@ pipeline {
                 }
             }
         }
+
+        stage('Prepare Codex auth.json') {
+            steps {
+                script {
+                    common.prepareCodexAuthFile()
+                }
+            }
+        }
+
 
         stage('Validate Parameters') {
             steps {
@@ -236,6 +247,13 @@ pipeline {
                         rm -rf ${env.REPOS_ROOT}
                     """
                     echo "REPOS_ROOT cleaned up: ${env.REPOS_ROOT}"
+                }
+
+                if (env.CODEX_HOME?.trim()) {
+                    sh """
+                        rm -rf ${env.CODEX_HOME}
+                    """
+                    echo "CODEX_HOME cleaned up: ${env.CODEX_HOME}"
                 }
             }
         }

--- a/jenkins/jobs/pipeline/ai-workflow/auto-issue/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/auto-issue/Jenkinsfile
@@ -11,6 +11,7 @@
  * - AUTO_ISSUE_SIMILARITY_THRESHOLD: 重複判定の類似度閾値（デフォルト: 0.8）
  * - AGENT_MODE: エージェントモード（デフォルト: auto）
  * - GITHUB_TOKEN: GitHub Personal Access Token（必須）
+ * - CODEX_AUTH_JSON: Codex ~/.codex/auth.json の内容（オプション）
  * - その他の認証情報（Jenkinsfile.all-phasesと同じ）
  * - DRY_RUN: ドライランモード（デフォルト: false、Issue生成せず検出結果のみ表示）
  *
@@ -41,6 +42,7 @@ pipeline {
         WORKFLOW_DIR = '.'
         WORKFLOW_VERSION = '0.2.0'
         EXECUTION_MODE = 'auto_issue'
+        CODEX_HOME = ''
         LOG_NO_COLOR = 'true'
 
         GIT_COMMIT_USER_NAME = "${params.GIT_COMMIT_USER_NAME ?: 'AI Workflow Bot'}"
@@ -83,6 +85,15 @@ pipeline {
                 }
             }
         }
+
+        stage('Prepare Codex auth.json') {
+            steps {
+                script {
+                    common.prepareCodexAuthFile()
+                }
+            }
+        }
+
 
         stage('Validate Parameters') {
             steps {
@@ -194,6 +205,13 @@ pipeline {
                         rm -rf ${env.REPOS_ROOT}
                     """
                     echo "REPOS_ROOT cleaned up: ${env.REPOS_ROOT}"
+                }
+
+                if (env.CODEX_HOME?.trim()) {
+                    sh """
+                        rm -rf ${env.CODEX_HOME}
+                    """
+                    echo "CODEX_HOME cleaned up: ${env.CODEX_HOME}"
                 }
             }
         }

--- a/jenkins/jobs/pipeline/ai-workflow/finalize/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/finalize/Jenkinsfile
@@ -17,6 +17,7 @@
  * - DRY_RUN: ドライランモード（デフォルト: false）
  * - AGENT_MODE: エージェントモード（デフォルト: auto）
  * - GITHUB_TOKEN: GitHub Personal Access Token（必須）
+ * - CODEX_AUTH_JSON: Codex ~/.codex/auth.json の内容（オプション）
  * - その他: APIキー、AWS認証情報、Git設定
  */
 
@@ -45,6 +46,7 @@ pipeline {
         WORKFLOW_DIR = '.'
         WORKFLOW_VERSION = '0.5.0'
         EXECUTION_MODE = 'finalize'
+        CODEX_HOME = ''
 
         // ログ設定（CI環境ではカラーリング無効化）
         LOG_NO_COLOR = 'true'
@@ -94,6 +96,15 @@ pipeline {
                 }
             }
         }
+
+        stage('Prepare Codex auth.json') {
+            steps {
+                script {
+                    common.prepareCodexAuthFile()
+                }
+            }
+        }
+
 
         stage('Validate Parameters') {
             steps {
@@ -229,6 +240,13 @@ pipeline {
                         rm -rf ${env.REPOS_ROOT}
                     """
                     echo "REPOS_ROOT cleaned up: ${env.REPOS_ROOT}"
+                }
+
+                if (env.CODEX_HOME?.trim()) {
+                    sh """
+                        rm -rf ${env.CODEX_HOME}
+                    """
+                    echo "CODEX_HOME cleaned up: ${env.CODEX_HOME}"
                 }
             }
         }

--- a/jenkins/jobs/pipeline/ai-workflow/preset/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/preset/Jenkinsfile
@@ -9,6 +9,7 @@
  * - PRESET: プリセット名（必須、選択肢: review-requirements, review-design, review-test-scenario, quick-fix, implementation, testing, finalize）
  * - AGENT_MODE: エージェントモード（デフォルト: auto）
  * - GITHUB_TOKEN: GitHub Personal Access Token（必須）
+ * - CODEX_AUTH_JSON: Codex ~/.codex/auth.json の内容（オプション）
  * - その他の認証情報（Jenkinsfile.all-phasesと同じ）
  */
 
@@ -34,6 +35,7 @@ pipeline {
         WORKFLOW_DIR = '.'
         WORKFLOW_VERSION = '0.2.0'
         EXECUTION_MODE = 'preset'
+        CODEX_HOME = ''
         LOG_NO_COLOR = 'true'
 
         GIT_COMMIT_USER_NAME = "${params.GIT_COMMIT_USER_NAME ?: 'AI Workflow Bot'}"
@@ -76,6 +78,15 @@ pipeline {
                 }
             }
         }
+
+        stage('Prepare Codex auth.json') {
+            steps {
+                script {
+                    common.prepareCodexAuthFile()
+                }
+            }
+        }
+
 
         stage('Validate Parameters') {
             steps {
@@ -209,6 +220,13 @@ pipeline {
                         rm -rf ${env.REPOS_ROOT}
                     """
                     echo "REPOS_ROOT cleaned up: ${env.REPOS_ROOT}"
+                }
+
+                if (env.CODEX_HOME?.trim()) {
+                    sh """
+                        rm -rf ${env.CODEX_HOME}
+                    """
+                    echo "CODEX_HOME cleaned up: ${env.CODEX_HOME}"
                 }
             }
         }

--- a/jenkins/jobs/pipeline/ai-workflow/rollback/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/rollback/Jenkinsfile
@@ -13,6 +13,7 @@
  * - ROLLBACK_MODE: 差し戻しモード（auto: エージェント自動判定 / manual: 従来の手動指定）
  * - AGENT_MODE: エージェントモード（デフォルト: auto）
  * - GITHUB_TOKEN: GitHub Personal Access Token（必須）
+ * - CODEX_AUTH_JSON: Codex ~/.codex/auth.json の内容（オプション）
  * - その他の認証情報（Jenkinsfile.all-phasesと同じ）
  *
  * 注意:
@@ -42,6 +43,7 @@ pipeline {
         WORKFLOW_DIR = '.'
         WORKFLOW_VERSION = '0.2.0'
         EXECUTION_MODE = 'rollback'
+        CODEX_HOME = ''
         ROLLBACK_MODE = "${params.ROLLBACK_MODE ?: 'auto'}"
         LOG_NO_COLOR = 'true'
 
@@ -83,6 +85,14 @@ pipeline {
             steps {
                 script {
                     common.prepareAgentCredentials()
+                }
+            }
+        }
+
+        stage('Prepare Codex auth.json') {
+            steps {
+                script {
+                    common.prepareCodexAuthFile()
                 }
             }
         }
@@ -264,6 +274,13 @@ pipeline {
                         rm -rf ${env.REPOS_ROOT}
                     """
                     echo "REPOS_ROOT cleaned up: ${env.REPOS_ROOT}"
+                }
+
+                if (env.CODEX_HOME?.trim()) {
+                    sh """
+                        rm -rf ${env.CODEX_HOME}
+                    """
+                    echo "CODEX_HOME cleaned up: ${env.CODEX_HOME}"
                 }
             }
         }

--- a/jenkins/jobs/pipeline/ai-workflow/single-phase/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/single-phase/Jenkinsfile
@@ -9,6 +9,7 @@
  * - START_PHASE: 実行するフェーズ名（必須、選択肢: planning, requirements, design, test-scenario, implementation, test-implementation, testing, documentation, report, evaluation）
  * - AGENT_MODE: エージェントモード（デフォルト: auto）
  * - GITHUB_TOKEN: GitHub Personal Access Token（必須）
+ * - CODEX_AUTH_JSON: Codex ~/.codex/auth.json の内容（オプション）
  * - その他の認証情報（Jenkinsfile.all-phasesと同じ）
  */
 
@@ -34,6 +35,7 @@ pipeline {
         WORKFLOW_DIR = '.'
         WORKFLOW_VERSION = '0.2.0'
         EXECUTION_MODE = 'single_phase'
+        CODEX_HOME = ''
         LOG_NO_COLOR = 'true'
 
         GIT_COMMIT_USER_NAME = "${params.GIT_COMMIT_USER_NAME ?: 'AI Workflow Bot'}"
@@ -76,6 +78,15 @@ pipeline {
                 }
             }
         }
+
+        stage('Prepare Codex auth.json') {
+            steps {
+                script {
+                    common.prepareCodexAuthFile()
+                }
+            }
+        }
+
 
         stage('Validate Parameters') {
             steps {
@@ -209,6 +220,13 @@ pipeline {
                         rm -rf ${env.REPOS_ROOT}
                     """
                     echo "REPOS_ROOT cleaned up: ${env.REPOS_ROOT}"
+                }
+
+                if (env.CODEX_HOME?.trim()) {
+                    sh """
+                        rm -rf ${env.CODEX_HOME}
+                    """
+                    echo "CODEX_HOME cleaned up: ${env.CODEX_HOME}"
                 }
             }
         }

--- a/jenkins/shared/common.groovy
+++ b/jenkins/shared/common.groovy
@@ -89,6 +89,37 @@ def prepareAgentCredentials() {
 }
 
 /**
+ * CODEX_AUTH_JSONパラメータから一時的なauth.jsonを展開
+ *
+ * Jenkinsのworkspace配下に ~/.codex/auth.json を書き出し、CODEX_HOMEを設定する。
+ * パラメータが空の場合は何もしない。
+ */
+def prepareCodexAuthFile() {
+    def codexAuth = params.CODEX_AUTH_JSON ?: ''
+    if (!codexAuth.trim()) {
+        echo "CODEX_AUTH_JSON is empty; skipping Codex auth setup."
+        env.CODEX_HOME = ''
+        return
+    }
+
+    def codexHome = "${env.WORKSPACE}/.codex"
+    def authFilePath = "${codexHome}/auth.json"
+
+    sh """
+        mkdir -p '${codexHome}'
+    """
+
+    writeFile file: authFilePath, text: codexAuth
+
+    sh """
+        chmod 600 '${authFilePath}'
+    """
+
+    env.CODEX_HOME = codexHome
+    echo "Codex auth.json prepared at ${authFilePath}"
+}
+
+/**
  * REPOS_ROOT準備と対象リポジトリのクローン
  *
  * 処理内容:
@@ -259,3 +290,4 @@ def archiveArtifacts(String issueNumber) {
 
 // Groovyスクリプトとして読み込み可能にするため、return this を末尾に追加
 return this
+


### PR DESCRIPTION
## Summary
- add CODEX_AUTH_JSON job parameters across Jenkins DSLs
- teach shared common library to write auth.json inside Jenkins workspace and set CODEX_HOME
- run the new stage + cleanup in each pipeline Jenkinsfile so Codex CLI can rely on the temporary auth file without touching the Docker image

## Testing
- not run (Jenkins pipeline/DSL changes require Jenkins to exercise)