### PR TITLE
fix(security): Exclude .codex/auth.json and other sensitive files from git commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,10 @@ sandbox/
 # Claude Code local settings
 .claude/settings.local.json
 
+# Codex CLI credentials (SECURITY: never commit)
+.codex/
+.codex/auth.json
+
 # OS
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
## Summary

- Git commit 操作から `.codex/auth.json` などの機密ファイルが誤ってコミットされないよう保護を追加
- すべての ai-workflow Git 操作で自動的に機密ファイルを除外

## 変更内容

### 1. `.gitignore` に追加
- `.codex/` ディレクトリ全体
- `.codex/auth.json`

### 2. `file-selector.ts` - セキュリティ除外ロジック
- `SECURITY_EXCLUDED_PATTERNS` 定数で機密ファイルパターンを定義
- `isSecuritySensitiveFile()` 関数をエクスポート
- `getChangedFiles()` と `filterPhaseFiles()` で機密ファイルを自動除外

### 3. `commit-manager.ts` - セキュリティチェック追加
- `commitWorkflowDeletion()` でも機密ファイルを除外

### 4. テスト追加
- `isSecuritySensitiveFile` 関数の単体テスト（6 ケース）
- `FileSelector` のセキュリティ除外テスト（3 ケース）

## 保護される機密ファイル

| パターン | 説明 |
|---------|------|
| `.codex/auth.json` | Codex CLI 認証情報 |
| `.codex/` | Codex ディレクトリ全体 |
| `auth.json` | 任意の認証ファイル |
| `credentials.json` | 認証情報ファイル |
| `.env` | 環境変数ファイル |
| `.env.local` | ローカル環境変数 |
| `.env.production` | 本番環境変数 |
| `.env.development` | 開発環境変数 |

## Test plan

- [x] `npm run build` - ビルド成功
- [x] `npx jest tests/unit/git/file-selector.test.ts` - 32 テスト通過（新規 9 テスト含む）
- [x] `isSecuritySensitiveFile` が機密ファイルを正しく検出
- [x] Windows パス区切り（`\`）も正しく処理

🤖 Generated with [Claude Code](https://claude.com/claude-code)