### PR TITLE
fix(codex): Remove unsupported --search option from Codex CLI

### DIFF
--- a/src/core/codex-agent-client.ts
+++ b/src/core/codex-agent-client.ts
@@ -38,14 +38,11 @@ export class CodexAgentClient {
 
   public async executeTask(options: ExecuteTaskOptions): Promise<string[]> {
     const cwd = options.workingDirectory ?? this.workingDir;
-    // Issue #309: Add --search to enable web search capability
-    // This allows Codex to access current API documentation and technical articles
     const args: string[] = [
       'exec',
       '--json',
       '--skip-git-repo-check',
       '--dangerously-bypass-approvals-and-sandbox',
-      '--search',
     ];
 
     const model = options.model ?? this.defaultModel;


### PR DESCRIPTION
## Summary
- Codex CLI で `--search` オプションがサポートされていないためエラーが発生
- オプションを削除して互換性を回復

## Error
```
error: unexpected argument '--search' found
  tip: to pass '--search' as a value, use '-- --search'
Usage: codex exec --json --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox [PROMPT]
```

## Changes
- `src/core/codex-agent-client.ts` から `--search` オプションを削除
- PR #310 (Issue #309) の一部をリバート

## Test plan
- [ ] Codex CLI でのタスク実行が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)