### PR TITLE
fix(jenkins): Add cleanWs() to all Jenkinsfiles for workspace cleanup

### DIFF
--- a/jenkins/jobs/pipeline/ai-workflow/all-phases/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/all-phases/Jenkinsfile
@@ -255,6 +255,10 @@ pipeline {
                     """
                     echo "CODEX_HOME cleaned up: ${env.CODEX_HOME}"
                 }
+
+                // ワークスペースのクリーンアップ
+                cleanWs()
+                echo "Workspace cleaned up"
             }
         }
 

--- a/jenkins/jobs/pipeline/ai-workflow/auto-issue/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/auto-issue/Jenkinsfile
@@ -214,6 +214,10 @@ pipeline {
                     """
                     echo "CODEX_HOME cleaned up: ${env.CODEX_HOME}"
                 }
+
+                // ワークスペースのクリーンアップ
+                cleanWs()
+                echo "Workspace cleaned up"
             }
         }
 

--- a/jenkins/jobs/pipeline/ai-workflow/finalize/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/finalize/Jenkinsfile
@@ -234,6 +234,10 @@ pipeline {
                 def dryRunLabel = params.DRY_RUN ? ' [DRY RUN]' : ''
                 currentBuild.description = "Issue #${env.ISSUE_NUMBER} | Finalize${dryRunLabel} | ${env.REPO_OWNER}/${env.REPO_NAME}"
 
+                if (env.ISSUE_NUMBER && env.ISSUE_NUMBER != 'auto') {
+                    common.archiveArtifacts(env.ISSUE_NUMBER)
+                }
+
                 // REPOS_ROOTクリーンアップ
                 if (env.REPOS_ROOT) {
                     sh """
@@ -248,6 +252,10 @@ pipeline {
                     """
                     echo "CODEX_HOME cleaned up: ${env.CODEX_HOME}"
                 }
+
+                // ワークスペースのクリーンアップ
+                cleanWs()
+                echo "Workspace cleaned up"
             }
         }
 

--- a/jenkins/jobs/pipeline/ai-workflow/preset/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/preset/Jenkinsfile
@@ -228,6 +228,10 @@ pipeline {
                     """
                     echo "CODEX_HOME cleaned up: ${env.CODEX_HOME}"
                 }
+
+                // ワークスペースのクリーンアップ
+                cleanWs()
+                echo "Workspace cleaned up"
             }
         }
 

--- a/jenkins/jobs/pipeline/ai-workflow/rollback/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/rollback/Jenkinsfile
@@ -282,6 +282,10 @@ pipeline {
                     """
                     echo "CODEX_HOME cleaned up: ${env.CODEX_HOME}"
                 }
+
+                // ワークスペースのクリーンアップ
+                cleanWs()
+                echo "Workspace cleaned up"
             }
         }
 

--- a/jenkins/jobs/pipeline/ai-workflow/single-phase/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/single-phase/Jenkinsfile
@@ -228,6 +228,10 @@ pipeline {
                     """
                     echo "CODEX_HOME cleaned up: ${env.CODEX_HOME}"
                 }
+
+                // ワークスペースのクリーンアップ
+                cleanWs()
+                echo "Workspace cleaned up"
             }
         }
 


### PR DESCRIPTION
## Summary
- Add `cleanWs()` call in `post.always` block to all Jenkinsfiles for workspace cleanup after each build
- Add missing `archiveArtifacts` call to finalize Jenkinsfile

## Changes
| Jenkinsfile | Changes |
|-------------|---------|
| all-phases | Add `cleanWs()` |
| preset | Add `cleanWs()` |
| single-phase | Add `cleanWs()` |
| rollback | Add `cleanWs()` |
| finalize | Add `cleanWs()`, Add `archiveArtifacts` |
| auto-issue | Add `cleanWs()` |

## Why
- Prevent disk space issues on Jenkins build agents
- Ensure clean workspace for subsequent builds
- Consistent cleanup behavior across all job types

## Test plan
- [ ] Run each Jenkinsfile type and verify workspace is cleaned up after build
- [ ] Verify artifacts are archived before cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)