### PR TITLE
fix(finalize): Use metadata pr_number instead of GitHub search API

### DIFF
--- a/src/commands/finalize.ts
+++ b/src/commands/finalize.ts
@@ -236,10 +236,18 @@ async function executeStep4And5(
   const githubClient = await createGitHubClient(metadataManager);
   const prClient = githubClient.getPullRequestClient();
 
-  // PR 番号の取得
-  const prNumber = await prClient.getPullRequestNumber(issueNumber);
+  // PR 番号の取得（メタデータから優先、フォールバックとして検索API）
+  let prNumber = metadataManager.data.pr_number;
+
   if (!prNumber) {
-    throw new Error(`Pull request not found for issue #${issueNumber}`);
+    logger.warn('PR number not found in metadata, searching via GitHub API...');
+    prNumber = await prClient.getPullRequestNumber(issueNumber);
+    if (!prNumber) {
+      throw new Error(
+        `Pull request not found for issue #${issueNumber}. ` +
+        'Make sure the PR was created during workflow initialization.'
+      );
+    }
   }
 
   logger.info(`Found PR #${prNumber}`);


### PR DESCRIPTION
Problem:
finalize command failed with "Pull request not found" error when trying to update PR. The getPullRequestNumber() search API was unreliable because:
1. It searches PR body for issue number (can match unrelated PRs)
2. PR body may have been updated/cleared during workflow

Solution:
Use pr_number from metadata.json as the primary source, with GitHub search API as a fallback only if metadata doesn't have the PR number.

Changes:
- Check metadataManager.data.pr_number first
- Fall back to prClient.getPullRequestNumber() only if not found
- Added warning log when falling back to search API
- Improved error message with troubleshooting hint

This ensures finalize command works reliably even after PR body changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)