### PR TITLE
fix(finalize): Initialize GitHubClient with target repository

### DIFF
--- a/src/commands/finalize.ts
+++ b/src/commands/finalize.ts
@@ -292,8 +292,13 @@ async function createGitHubClient(metadataManager: MetadataManager): Promise<Git
     throw new Error('target_repository not found in metadata');
   }
 
-  // GitHubClient は環境変数から自動的に認証情報を取得する
-  const githubClient = new GitHubClient();
+  // owner/repo 形式のリポジトリ名を構築
+  const repositoryName = `${targetRepo.owner}/${targetRepo.repo}`;
+  logger.debug(`Initializing GitHubClient for repository: ${repositoryName}`);
+
+  // GitHubClient を対象リポジトリで初期化
+  // token は環境変数から自動取得、repository を明示的に指定
+  const githubClient = new GitHubClient(null, repositoryName);
   return githubClient;
 }
 


### PR DESCRIPTION
Problem:
finalize command failed with 404 error when updating PR:
  "GitHub API error: 404 - Not Found"

The GitHubClient was initialized without specifying the target repository, causing it to fall back to GITHUB_REPOSITORY environment variable. This pointed to ai-workflow-agent repository instead of the actual target repository (e.g., docs-generator).

Solution:
Initialize GitHubClient with the target repository from metadata:

Changes:
- Extract owner/repo from metadata.target_repository
- Pass repositoryName to GitHubClient constructor
- Added debug log to show which repository is being used
- Token still auto-loaded from environment (null parameter)

This ensures PR operations target the correct repository where the workflow is actually running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)