### PR TITLE
[auto-issue] Add LOG_LEVEL parameter to pr-comment Jenkins jobs

### DIFF
--- a/jenkins/jobs/dsl/ai-workflow/ai_workflow_pr_comment_execute_job.groovy
+++ b/jenkins/jobs/dsl/ai-workflow/ai_workflow_pr_comment_execute_job.groovy
@@ -89,6 +89,14 @@ Git コミットユーザー名
 Git コミットメールアドレス
             '''.stripIndent().trim())
 
+            choiceParam('LOG_LEVEL', ['INFO', 'DEBUG', 'WARNING', 'ERROR'], '''
+ログレベル
+- DEBUG: 詳細なデバッグ情報を出力
+- INFO: 通常の情報を出力（デフォルト）
+- WARNING: 警告のみ出力
+- ERROR: エラーのみ出力
+            '''.stripIndent().trim())
+
             // ========================================
             // APIキー設定
             // ========================================

--- a/jenkins/jobs/dsl/ai-workflow/ai_workflow_pr_comment_finalize_job.groovy
+++ b/jenkins/jobs/dsl/ai-workflow/ai_workflow_pr_comment_finalize_job.groovy
@@ -76,6 +76,14 @@ Git コミットユーザー名
 Git コミットメールアドレス
             '''.stripIndent().trim())
 
+            choiceParam('LOG_LEVEL', ['INFO', 'DEBUG', 'WARNING', 'ERROR'], '''
+ログレベル
+- DEBUG: 詳細なデバッグ情報を出力
+- INFO: 通常の情報を出力（デフォルト）
+- WARNING: 警告のみ出力
+- ERROR: エラーのみ出力
+            '''.stripIndent().trim())
+
             // ========================================
             // APIキー設定
             // ========================================

--- a/jenkins/jobs/pipeline/ai-workflow/pr-comment-execute/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/pr-comment-execute/Jenkinsfile
@@ -41,7 +41,8 @@ pipeline {
         EXECUTION_MODE = 'pr_comment_execute'
         CODEX_HOME = ''
 
-        // ログ設定（CI環境ではカラーリング無効化）
+        // ログ設定
+        LOG_LEVEL = "${(params.LOG_LEVEL ?: 'INFO').toLowerCase()}"
         LOG_NO_COLOR = 'true'
 
         // Git設定

--- a/jenkins/jobs/pipeline/ai-workflow/pr-comment-finalize/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/pr-comment-finalize/Jenkinsfile
@@ -38,7 +38,8 @@ pipeline {
         EXECUTION_MODE = 'pr_comment_finalize'
         CODEX_HOME = ''
 
-        // ログ設定（CI環境ではカラーリング無効化）
+        // ログ設定
+        LOG_LEVEL = "${(params.LOG_LEVEL ?: 'INFO').toLowerCase()}"
         LOG_NO_COLOR = 'true'
 
         // Git設定


### PR DESCRIPTION
Add LOG_LEVEL parameter to both pr-comment-execute and pr-comment-finalize Job DSL and Jenkinsfile to enable debug logging for troubleshooting.

Changes:
- Job DSL: Add LOG_LEVEL choice parameter (INFO|DEBUG|WARNING|ERROR)
- Jenkinsfile: Convert parameter to lowercase and set LOG_LEVEL env var
- Default: INFO (to maintain current behavior)
- Consistent with other Job DSL files (uppercase choices)

Usage:
- Set LOG_LEVEL=DEBUG to see detailed GraphQL/REST API responses
- Useful for debugging "No unresolved comments found" issues

Technical details:
- Parameter uses uppercase (INFO, DEBUG, WARNING, ERROR)
- Jenkinsfile converts to lowercase (info, debug, warning, error)
- Logger module expects lowercase values

🤖 Generated with [Claude Code](https://claude.com/claude-code)