### PR TITLE
[auto-issue] Add Git commit & push to pr-comment init

### DIFF
--- a/src/commands/pr-comment/init.ts
+++ b/src/commands/pr-comment/init.ts
@@ -40,6 +40,19 @@ export async function handlePRCommentInitCommand(options: PRCommentInitOptions):
     displaySummary(summary);
 
     logger.info(`Initialization completed. Metadata saved to: ${metadataManager.getMetadataPath()}`);
+
+    // Git コミット & プッシュ
+    const git = simpleGit(repoInfo.path);
+    const metadataPath = metadataManager.getMetadataPath();
+    const relativePath = metadataPath.replace(`${repoInfo.path}/`, '').replace(/\\/g, '/');
+
+    logger.info('Committing PR comment metadata...');
+    await git.add(relativePath);
+    await git.commit(`[pr-comment] Initialize PR #${prNumber} comment resolution metadata`);
+
+    logger.info('Pushing to remote...');
+    await git.push();
+    logger.info('Metadata committed and pushed to remote.');
   } catch (error) {
     logger.error(`Failed to initialize: ${getErrorMessage(error)}`);
     process.exit(1);


### PR DESCRIPTION
Add Git commit and push functionality to pr-comment init command to ensure metadata is persisted to remote repository.

Changes:
- Import simple-git for Git operations
- Add git.add() for metadata file after initialization
- Add git.commit() with descriptive message
- Add git.push() to push to remote repository
- Normalize file paths (Windows backslash to forward slash)

Benefits:
- Metadata is automatically committed to repository
- Remote repository has metadata for pr-comment execute/finalize
- Consistent with main workflow init command behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)