### PR TITLE
[auto-issue] Fix Git config for pr-comment init commit

### DIFF
--- a/src/commands/pr-comment/init.ts
+++ b/src/commands/pr-comment/init.ts
@@ -4,6 +4,7 @@ import { logger } from '../../utils/logger.js';
 import { getErrorMessage } from '../../utils/error-utils.js';
 import { PRCommentMetadataManager } from '../../core/pr-comment/metadata-manager.js';
 import { GitHubClient } from '../../core/github-client.js';
+import { config } from '../../core/config.js';
 import { PRCommentInitOptions } from '../../types/commands.js';
 import { PRInfo, RepositoryInfo, ReviewComment, ResolutionSummary } from '../../types/pr-comment.js';
 import { getRepoRoot, parsePullRequestUrl } from '../../core/repository-utils.js';
@@ -45,6 +46,14 @@ export async function handlePRCommentInitCommand(options: PRCommentInitOptions):
     const git = simpleGit(repoInfo.path);
     const metadataPath = metadataManager.getMetadataPath();
     const relativePath = metadataPath.replace(`${repoInfo.path}/`, '').replace(/\\/g, '/');
+
+    // Git設定（環境変数から取得、デフォルト値使用）
+    const gitUserName = config.getGitCommitUserName() || 'AI Workflow Bot';
+    const gitUserEmail = config.getGitCommitUserEmail() || 'ai-workflow@example.com';
+
+    logger.debug(`Configuring Git user: ${gitUserName} <${gitUserEmail}>`);
+    await git.addConfig('user.name', gitUserName);
+    await git.addConfig('user.email', gitUserEmail);
 
     logger.info('Committing PR comment metadata...');
     await git.add(relativePath);


### PR DESCRIPTION
Fix Git user identity error by configuring user.name and user.email from environment variables before committing.

Root cause:
- simple-git requires Git config to be set before commit
- GIT_COMMIT_USER_NAME and GIT_COMMIT_USER_EMAIL env vars were set but not applied to Git config

Solution:
- Import config module to access environment variables
- Call git.addConfig() for user.name and user.email before commit
- Provide default values if environment variables are not set

Changes:
- Import config module
- Add Git config setup before commit
- Use config.getGitCommitUserName() and getGitCommitUserEmail()
- Add default values: 'AI Workflow Bot' and 'ai-workflow@example.com'

🤖 Generated with [Claude Code](https://claude.com/claude-code)