### PR TITLE
[auto-issue] Fix jq syntax in Jenkinsfiles for PR branch detection

### DIFF
--- a/jenkins/jobs/pipeline/ai-workflow/pr-comment-execute/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/pr-comment-execute/Jenkinsfile
@@ -121,7 +121,7 @@ pipeline {
 
                     // GitHub APIでPR情報を取得してブランチ名を設定
                     def prInfo = sh(
-                        script: "gh api repos/${env.REPO_OWNER}/${env.REPO_NAME}/pulls/${env.PR_NUMBER} --jq '{head: .head.ref, base: .base.ref}' 2>/dev/null || echo '{\"head\":\"\",\"base\":\"\"}'",
+                        script: "gh api repos/${env.REPO_OWNER}/${env.REPO_NAME}/pulls/${env.PR_NUMBER} --jq '{\"head\":.head.ref,\"base\":.base.ref}' 2>/dev/null || echo '{\"head\":\"\",\"base\":\"\"}'",
                         returnStdout: true
                     ).trim()
 

--- a/jenkins/jobs/pipeline/ai-workflow/pr-comment-finalize/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/pr-comment-finalize/Jenkinsfile
@@ -102,7 +102,7 @@ pipeline {
 
                     // GitHub APIでPR情報を取得してブランチ名を設定
                     def prInfo = sh(
-                        script: "gh api repos/${env.REPO_OWNER}/${env.REPO_NAME}/pulls/${env.PR_NUMBER} --jq '{head: .head.ref, base: .base.ref}' 2>/dev/null || echo '{\"head\":\"\",\"base\":\"\"}'",
+                        script: "gh api repos/${env.REPO_OWNER}/${env.REPO_NAME}/pulls/${env.PR_NUMBER} --jq '{\"head\":.head.ref,\"base\":.base.ref}' 2>/dev/null || echo '{\"head\":\"\",\"base\":\"\"}'",
                         returnStdout: true
                     ).trim()
 


### PR DESCRIPTION
Fix Groovy string interpolation conflict with jq JSON object syntax by escaping quotes in jq filter.

Root cause:
- jq filter used unescaped braces: {head: .head.ref, base: .base.ref}
- Groovy interpreter tried to interpolate the braces as variables
- Resulted in syntax error and Jenkins agent disconnection

Solution:
- Escape quotes in jq JSON keys: {"head":.head.ref,"base":.base.ref}
- Remove spaces to avoid potential parsing issues
- Maintain fallback to empty JSON on error

Changes:
- pr-comment-execute: Fix jq filter syntax
- pr-comment-finalize: Fix jq filter syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)