### PR TITLE
[auto-issue] Fix shell quoting for jq in Jenkinsfiles

### DIFF
--- a/jenkins/jobs/pipeline/ai-workflow/pr-comment-execute/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/pr-comment-execute/Jenkinsfile
@@ -121,7 +121,7 @@ pipeline {
 
                     // GitHub APIでPR情報を取得してブランチ名を設定
                     def prInfo = sh(
-                        script: "gh api repos/${env.REPO_OWNER}/${env.REPO_NAME}/pulls/${env.PR_NUMBER} --jq '{\"head\":.head.ref,\"base\":.base.ref}' 2>/dev/null || echo '{\"head\":\"\",\"base\":\"\"}'",
+                        script: '''gh api repos/''' + env.REPO_OWNER + '''/''' + env.REPO_NAME + '''/pulls/''' + env.PR_NUMBER + ''' --jq '{"head":.head.ref,"base":.base.ref}' 2>/dev/null || echo '{"head":"","base":""}'  ''',
                         returnStdout: true
                     ).trim()
 

--- a/jenkins/jobs/pipeline/ai-workflow/pr-comment-finalize/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/pr-comment-finalize/Jenkinsfile
@@ -102,7 +102,7 @@ pipeline {
 
                     // GitHub APIでPR情報を取得してブランチ名を設定
                     def prInfo = sh(
-                        script: "gh api repos/${env.REPO_OWNER}/${env.REPO_NAME}/pulls/${env.PR_NUMBER} --jq '{\"head\":.head.ref,\"base\":.base.ref}' 2>/dev/null || echo '{\"head\":\"\",\"base\":\"\"}'",
+                        script: '''gh api repos/''' + env.REPO_OWNER + '''/''' + env.REPO_NAME + '''/pulls/''' + env.PR_NUMBER + ''' --jq '{"head":.head.ref,"base":.base.ref}' 2>/dev/null || echo '{"head":"","base":""}'  ''',
                         returnStdout: true
                     ).trim()
 


### PR DESCRIPTION
Fix shell command quoting by using Groovy triple-quoted strings to properly pass single quotes to shell for jq JSON filter.

Root cause:
- Double quotes in shell script were not properly escaped
- Shell received: --jq {"head":.head.ref,"base":.base.ref}
- Shell split arguments incorrectly, causing syntax error

Solution:
- Use Groovy triple quotes (''') to preserve shell single quotes
- Shell receives: --jq '{"head":.head.ref,"base":.base.ref}'
- jq correctly parses JSON filter with single-quoted argument

Changes:
- pr-comment-execute: Use triple-quoted string concatenation
- pr-comment-finalize: Use triple-quoted string concatenation

Technical details:
- Triple quotes preserve literal single quotes in shell
- String concatenation with + for variable interpolation
- Fallback echo command also uses single quotes

🤖 Generated with [Claude Code](https://claude.com/claude-code)