### PR TITLE
[auto-issue] Simplify PR branch detection with separate jq calls

### DIFF
--- a/jenkins/jobs/pipeline/ai-workflow/pr-comment-execute/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/pr-comment-execute/Jenkinsfile
@@ -120,14 +120,15 @@ pipeline {
                     env.GITHUB_REPOSITORY = "${env.REPO_OWNER}/${env.REPO_NAME}"
 
                     // GitHub APIでPR情報を取得してブランチ名を設定
-                    def prInfo = sh(
-                        script: '''gh api repos/''' + env.REPO_OWNER + '''/''' + env.REPO_NAME + '''/pulls/''' + env.PR_NUMBER + ''' --jq '{"head":.head.ref,"base":.base.ref}' 2>/dev/null || echo '{"head":"","base":""}'  ''',
+                    env.BRANCH_NAME = sh(
+                        script: "gh api repos/${env.REPO_OWNER}/${env.REPO_NAME}/pulls/${env.PR_NUMBER} --jq .head.ref 2>/dev/null || echo unknown-branch",
                         returnStdout: true
                     ).trim()
 
-                    def prInfoJson = readJSON text: prInfo
-                    env.BRANCH_NAME = prInfoJson.head ?: "unknown-branch"
-                    env.BASE_BRANCH = prInfoJson.base ?: "main"
+                    env.BASE_BRANCH = sh(
+                        script: "gh api repos/${env.REPO_OWNER}/${env.REPO_NAME}/pulls/${env.PR_NUMBER} --jq .base.ref 2>/dev/null || echo main",
+                        returnStdout: true
+                    ).trim()
 
                     def dryRunLabel = params.DRY_RUN ? ' [DRY RUN]' : ''
                     currentBuild.description = "PR #${env.PR_NUMBER}${dryRunLabel} | Execute | ${env.REPO_OWNER}/${env.REPO_NAME}"

--- a/jenkins/jobs/pipeline/ai-workflow/pr-comment-finalize/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/pr-comment-finalize/Jenkinsfile
@@ -101,14 +101,15 @@ pipeline {
                     env.GITHUB_REPOSITORY = "${env.REPO_OWNER}/${env.REPO_NAME}"
 
                     // GitHub APIでPR情報を取得してブランチ名を設定
-                    def prInfo = sh(
-                        script: '''gh api repos/''' + env.REPO_OWNER + '''/''' + env.REPO_NAME + '''/pulls/''' + env.PR_NUMBER + ''' --jq '{"head":.head.ref,"base":.base.ref}' 2>/dev/null || echo '{"head":"","base":""}'  ''',
+                    env.BRANCH_NAME = sh(
+                        script: "gh api repos/${env.REPO_OWNER}/${env.REPO_NAME}/pulls/${env.PR_NUMBER} --jq .head.ref 2>/dev/null || echo unknown-branch",
                         returnStdout: true
                     ).trim()
 
-                    def prInfoJson = readJSON text: prInfo
-                    env.BRANCH_NAME = prInfoJson.head ?: "unknown-branch"
-                    env.BASE_BRANCH = prInfoJson.base ?: "main"
+                    env.BASE_BRANCH = sh(
+                        script: "gh api repos/${env.REPO_OWNER}/${env.REPO_NAME}/pulls/${env.PR_NUMBER} --jq .base.ref 2>/dev/null || echo main",
+                        returnStdout: true
+                    ).trim()
 
                     def dryRunLabel = params.DRY_RUN ? ' [DRY RUN]' : ''
                     currentBuild.description = "PR #${env.PR_NUMBER}${dryRunLabel} | Finalize | ${env.REPO_OWNER}/${env.REPO_NAME}"


### PR DESCRIPTION
Simplify GitHub API calls by using separate jq queries for head and base branches instead of constructing JSON object, avoiding quoting issues.

Root cause:
- Complex jq JSON object construction caused quoting issues in Groovy
- Triple-quoted strings didn't properly escape for shell execution
- Agent disconnection due to syntax errors

Solution:
- Use two separate gh api calls with simple jq filters
- First call: --jq .head.ref (no quotes needed for simple path)
- Second call: --jq .base.ref
- Simpler, more reliable, and avoids all quoting issues

Changes:
- pr-comment-execute: Split into two separate API calls
- pr-comment-finalize: Split into two separate API calls
- Remove readJSON text parsing (no longer needed)
- Direct assignment to env.BRANCH_NAME and env.BASE_BRANCH

Trade-offs:
- Two API calls instead of one (negligible overhead)
- Much simpler code and more reliable execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)