### PR TITLE
fix: Sanitize Git URL in logger output to prevent token leakage (Issue #493)

### DIFF
--- a/src/core/git/remote-manager.ts
+++ b/src/core/git/remote-manager.ts
@@ -2,6 +2,7 @@ import { setTimeout as delay } from 'node:timers/promises';
 import { logger } from '../../utils/logger.js';
 import { config } from '../config.js';
 import { getErrorMessage } from '../../utils/error-utils.js';
+import { sanitizeGitUrl } from '../../utils/git-url-utils.js';
 import type { SimpleGit, PushResult } from 'simple-git';
 import type { MetadataManager } from '../metadata-manager.js';
 
@@ -290,7 +291,7 @@ export class RemoteManager {
 
       if (!currentUrl.startsWith('https://github.com/')) {
         logger.info(
-          `Git remote URL is not HTTPS, skipping token configuration: ${currentUrl}`,
+          `Git remote URL is not HTTPS, skipping token configuration: ${sanitizeGitUrl(currentUrl)}`,
         );
         return;
       }


### PR DESCRIPTION
## 概要

**Critical Security Fix**: Jenkins ビルドログに GitHub Personal Access Token が平文で記録される問題を修正しました。

## 問題

`remote-manager.ts` で Git URL をログ出力する際、認証情報（トークン）が含まれたままログに記録されていました。

```typescript
// Before (問題あり)
logger.info(`Git remote URL is not HTTPS, skipping token configuration: ${currentUrl}`);
// ログ出力例: https://ghp_xxxxx@github.com/owner/repo.git
```

## 修正内容

既存の `sanitizeGitUrl()` ユーティリティを使用して、ログ出力前に認証情報を削除するよう修正しました。

```typescript
// After (修正後)
logger.info(`Git remote URL is not HTTPS, skipping token configuration: ${sanitizeGitUrl(currentUrl)}`);
// ログ出力例: https://github.com/owner/repo.git
```

## 変更ファイル

- `src/core/git/remote-manager.ts`
  - `sanitizeGitUrl()` を import
  - Line 294 でログ出力前に URL をサニタイズ

## テスト方法

1. Jenkins でワークフローを実行
2. ビルドログを確認
3. トークンが `***` または削除されて表示されることを確認

## 関連 Issue

- Fixes #493

## セキュリティ影響

- **修正前**: Jenkins ログにトークンが平文で記録され、アクセス権のある全員が閲覧可能
- **修正後**: トークンはログに記録されず、安全に運用可能

🚨 **重要**: この修正をマージ後、Jenkins の過去のビルドログに記録されたトークンを無効化してください。