### PR TITLE
fix: Use readJSON to avoid SecretMasker placeholders in PR URLs

### DIFF
--- a/jenkins/jobs/pipeline/ai-workflow/all-phases/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/all-phases/Jenkinsfile
@@ -242,13 +242,17 @@ pipeline {
                                     ${squashFlag}
                             """
 
-                            // PR URL を execute 実行後に取得（--cleanup-on-complete で .ai-workflow が削除される前）
+                            // metadata.json から PR URL を直接読み込み（readJSON を使用して SecretMasker を回避）
                             try {
-                                env.PR_URL = sh(
-                                    script: "cat .ai-workflow/issue-${env.ISSUE_NUMBER}/metadata.json 2>/dev/null | jq -r '.pr_url // empty' 2>/dev/null || echo ''",
-                                    returnStdout: true
-                                ).trim()
-                                echo "Retrieved PR URL: ${env.PR_URL}"
+                                def metadataFile = ".ai-workflow/issue-${env.ISSUE_NUMBER}/metadata.json"
+                                if (fileExists(metadataFile)) {
+                                    def metadata = readJSON file: metadataFile
+                                    env.PR_URL = metadata.pr_url ?: ''
+                                    echo "Retrieved PR URL from metadata: ${env.PR_URL}"
+                                } else {
+                                    env.PR_URL = ''
+                                    echo "Metadata file not found"
+                                }
                             } catch (Exception e) {
                                 echo "Could not retrieve PR URL: ${e.message}"
                                 env.PR_URL = ''

--- a/jenkins/jobs/pipeline/ai-workflow/pr-comment-execute/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/pr-comment-execute/Jenkinsfile
@@ -335,14 +335,10 @@ pipeline {
                 echo "PR: #${env.PR_NUMBER}"
                 echo "Repository: ${env.REPO_OWNER}/${env.REPO_NAME}"
 
-                def prUrl = ''
-                try {
-                    prUrl = sh(
-                        script: "cat .ai-workflow/issue-${env.ISSUE_NUMBER}/metadata.json 2>/dev/null | jq -r '.pr_url // empty' 2>/dev/null || echo ''",
-                        returnStdout: true
-                    ).trim()
-                } catch (Exception e) {
-                    echo "Could not retrieve PR URL: ${e.message}"
+                // params.PR_URL を直接使用（SecretMasker の影響を回避）
+                def prUrl = params.PR_URL ?: ''
+                if (prUrl) {
+                    echo "PR URL: ${prUrl}"
                 }
 
                 common.sendWebhook([

--- a/jenkins/jobs/pipeline/ai-workflow/preset/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/preset/Jenkinsfile
@@ -216,13 +216,17 @@ pipeline {
                                     ${squashFlag}
                             """
 
-                            // PR URL を execute 実行後に取得（--cleanup-on-complete で .ai-workflow が削除される前）
+                            // metadata.json から PR URL を直接読み込み（readJSON を使用して SecretMasker を回避）
                             try {
-                                env.PR_URL = sh(
-                                    script: "cat .ai-workflow/issue-${env.ISSUE_NUMBER}/metadata.json 2>/dev/null | jq -r '.pr_url // empty' 2>/dev/null || echo ''",
-                                    returnStdout: true
-                                ).trim()
-                                echo "Retrieved PR URL: ${env.PR_URL}"
+                                def metadataFile = ".ai-workflow/issue-${env.ISSUE_NUMBER}/metadata.json"
+                                if (fileExists(metadataFile)) {
+                                    def metadata = readJSON file: metadataFile
+                                    env.PR_URL = metadata.pr_url ?: ''
+                                    echo "Retrieved PR URL from metadata: ${env.PR_URL}"
+                                } else {
+                                    env.PR_URL = ''
+                                    echo "Metadata file not found"
+                                }
                             } catch (Exception e) {
                                 echo "Could not retrieve PR URL: ${e.message}"
                                 env.PR_URL = ''

--- a/jenkins/jobs/pipeline/ai-workflow/rollback/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/rollback/Jenkinsfile
@@ -312,12 +312,17 @@ pipeline {
                 echo "Rollback Target: ${targetLabel}"
                 echo "Workflow Directory: .ai-workflow/issue-${env.ISSUE_NUMBER}"
 
+                // metadata.json から PR URL を読み込み（readJSON を使用して SecretMasker を回避）
                 def prUrl = ''
                 try {
-                    prUrl = sh(
-                        script: "cat .ai-workflow/issue-${env.ISSUE_NUMBER}/metadata.json 2>/dev/null | jq -r '.pr_url // empty' 2>/dev/null || echo ''",
-                        returnStdout: true
-                    ).trim()
+                    def metadataFile = ".ai-workflow/issue-${env.ISSUE_NUMBER}/metadata.json"
+                    if (fileExists(metadataFile)) {
+                        def metadata = readJSON file: metadataFile
+                        prUrl = metadata.pr_url ?: ''
+                        if (prUrl) {
+                            echo "PR URL: ${prUrl}"
+                        }
+                    }
                 } catch (Exception e) {
                     echo "Could not retrieve PR URL: ${e.message}"
                 }

--- a/jenkins/jobs/pipeline/ai-workflow/single-phase/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/single-phase/Jenkinsfile
@@ -216,13 +216,17 @@ pipeline {
                                     ${squashFlag}
                             """
 
-                            // PR URL を execute 実行後に取得（--cleanup-on-complete で .ai-workflow が削除される前）
+                            // metadata.json から PR URL を直接読み込み（readJSON を使用して SecretMasker を回避）
                             try {
-                                env.PR_URL = sh(
-                                    script: "cat .ai-workflow/issue-${env.ISSUE_NUMBER}/metadata.json 2>/dev/null | jq -r '.pr_url // empty' 2>/dev/null || echo ''",
-                                    returnStdout: true
-                                ).trim()
-                                echo "Retrieved PR URL: ${env.PR_URL}"
+                                def metadataFile = ".ai-workflow/issue-${env.ISSUE_NUMBER}/metadata.json"
+                                if (fileExists(metadataFile)) {
+                                    def metadata = readJSON file: metadataFile
+                                    env.PR_URL = metadata.pr_url ?: ''
+                                    echo "Retrieved PR URL from metadata: ${env.PR_URL}"
+                                } else {
+                                    env.PR_URL = ''
+                                    echo "Metadata file not found"
+                                }
                             } catch (Exception e) {
                                 echo "Could not retrieve PR URL: ${e.message}"
                                 env.PR_URL = ''


### PR DESCRIPTION
- Replace sh(cat metadata.json | jq) with readJSON for PR URL retrieval
- readJSON bypasses SecretMasker, preventing __GITHUB_URL_X__ placeholders
- Use params.PR_URL directly in pr-comment-execute (no metadata needed)
- Fix incorrect assumption that Issue URL and PR URL have same number

Affected Jenkinsfiles:
- all-phases: Use readJSON to read metadata.json
- preset: Use readJSON to read metadata.json
- single-phase: Use readJSON to read metadata.json
- rollback: Use readJSON to read metadata.json
- pr-comment-execute: Use params.PR_URL directly