### PR TITLE
fix: Convert rollback.test.ts and finalize.test.ts to real file system (Batch 9)

### DIFF
--- a/src/commands/finalize.ts
+++ b/src/commands/finalize.ts
@@ -116,7 +116,7 @@ function validateFinalizeOptions(options: FinalizeCommandOptions): void {
   }
 
   // baseBranch チェック（指定されている場合のみ）
-  if (options.baseBranch && options.baseBranch.trim().length === 0) {
+  if (options.baseBranch !== undefined && options.baseBranch.trim().length === 0) {
     throw new Error('Error: --base-branch cannot be empty');
   }
 }

--- a/tests/unit/commands/finalize.test.ts
+++ b/tests/unit/commands/finalize.test.ts
@@ -11,39 +11,17 @@
  * テスト戦略: UNIT_INTEGRATION - ユニット部分
  */
 
-import { describe, test, expect, jest, beforeEach } from '@jest/globals';
+import { describe, test, expect, jest, beforeEach, afterEach } from '@jest/globals';
 import type { FinalizeCommandOptions } from '../../../src/commands/finalize.js';
 import { MetadataManager } from '../../../src/core/metadata-manager.js';
 import * as path from 'node:path';
-
-// node:fs のモック - モック化してからインポート
-const fsMock = {
-  existsSync: jest.fn<any>(),
-  mkdirSync: jest.fn<any>(),
-  writeFileSync: jest.fn<any>(),
-  readFileSync: jest.fn<any>(),
-  statSync: jest.fn<any>(),
-  readdirSync: jest.fn<any>(),
-  ensureDirSync: jest.fn<any>(),
-  removeSync: jest.fn<any>(),
-};
-
-jest.mock('fs-extra', () => ({
-  __esModule: true,
-  default: fsMock,
-  ...fsMock,
-}));
-
-// repository-utilsのモック
-jest.mock('../../../src/core/repository-utils.js', () => ({
-  __esModule: true,
-  findWorkflowMetadata: jest.fn<any>(),
-}));
-
 import fs from 'fs-extra';
-import { findWorkflowMetadata } from '../../../src/core/repository-utils.js';
 
 describe('Finalize コマンド - バリデーション（validateFinalizeOptions）', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   // =============================================================================
   // UC-08: validation_異常系_issue番号なし
   // =============================================================================
@@ -112,22 +90,65 @@ describe('Finalize コマンド - バリデーション（validateFinalizeOption
 });
 
 describe('Finalize コマンド - PR本文生成（generateFinalPrBody）', () => {
-  const testWorkflowDir = '/test/.ai-workflow/issue-123';
+  const testWorkflowDir = path.join(process.cwd(), '.ai-workflow', 'issue-123-finalize');
   const testMetadataPath = path.join(testWorkflowDir, 'metadata.json');
   let metadataManager: MetadataManager;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    fsMock.existsSync.mockReturnValue(true);
-    fsMock.ensureDirSync.mockImplementation(() => undefined as any);
-    fsMock.writeFileSync.mockImplementation(() => undefined);
+
+    // 実ファイルシステムを使用（MetadataManagerが実際のfs-extraを呼び出すため）
+    fs.ensureDirSync(path.dirname(testMetadataPath));
+
+    const basePhase = {
+      status: 'pending',
+      completed_steps: [],
+      current_step: null,
+      started_at: null,
+      completed_at: null,
+      review_result: null,
+      retry_count: 0,
+      rollback_context: null,
+    };
+
+    const metadataData = {
+      issue_number: '123',
+      issue_title: 'feat(cli): Add finalize command',
+      issue_url: 'https://github.com/owner/repo/issues/123',
+      created_at: '',
+      updated_at: '',
+      current_phase: 'planning',
+      phases: {
+        planning: { ...basePhase },
+        requirements: { ...basePhase },
+        design: { ...basePhase },
+        test_scenario: { ...basePhase },
+        implementation: { ...basePhase },
+        test_implementation: { ...basePhase },
+        testing: { ...basePhase },
+        documentation: { ...basePhase },
+        report: { ...basePhase },
+        evaluation: { ...basePhase },
+      },
+      github_integration: { progress_comment_url: null },
+      costs: { total_input_tokens: 0, total_output_tokens: 0, total_cost_usd: 0 },
+      design_decisions: {},
+      model_config: null,
+      difficulty_analysis: null,
+      rollback_history: [],
+    };
+
+    // 実ファイルを作成
+    fs.writeJsonSync(testMetadataPath, metadataData, { spaces: 2 });
 
     metadataManager = new MetadataManager(testMetadataPath);
+  });
 
-    // Issue情報を設定 (WorkflowMetadataの実際の型に合わせる)
-    metadataManager.data.issue_number = '123';  // string型
-    metadataManager.data.issue_title = 'feat(cli): Add finalize command';
-    metadataManager.data.issue_url = 'https://github.com/owner/repo/issues/123';
+  afterEach(() => {
+    // テスト後にクリーンアップ
+    if (fs.existsSync(testWorkflowDir)) {
+      fs.removeSync(testWorkflowDir);
+    }
   });
 
   // =============================================================================
@@ -197,17 +218,52 @@ describe('Finalize コマンド - PR本文生成（generateFinalPrBody）', () =
 });
 
 describe('Finalize コマンド - プレビューモード（previewFinalize）', () => {
-  const testWorkflowDir = '/test/.ai-workflow/issue-123';
+  const testWorkflowDir = path.join(process.cwd(), '.ai-workflow', 'issue-123');
   const testMetadataPath = path.join(testWorkflowDir, 'metadata.json');
 
   beforeEach(() => {
     jest.clearAllMocks();
 
-    // findWorkflowMetadataのモック設定
-    (findWorkflowMetadata as jest.MockedFunction<typeof findWorkflowMetadata>).mockResolvedValue({
-      repoRoot: '/test/repo',
-      metadataPath: testMetadataPath,
-    });
+    // 実ファイルシステムを使用
+    fs.ensureDirSync(path.dirname(testMetadataPath));
+
+    const metadataData = {
+      issue_number: '123',
+      base_commit: 'abc123',
+      issue_url: '',
+      issue_title: '',
+      created_at: '',
+      updated_at: '',
+      current_phase: 'evaluation',
+      phases: {
+        planning: { status: 'completed', completed_steps: [], current_step: null, started_at: null, completed_at: null, review_result: null, retry_count: 0, rollback_context: null },
+        requirements: { status: 'completed', completed_steps: [], current_step: null, started_at: null, completed_at: null, review_result: null, retry_count: 0, rollback_context: null },
+        design: { status: 'completed', completed_steps: [], current_step: null, started_at: null, completed_at: null, review_result: null, retry_count: 0, rollback_context: null },
+        test_scenario: { status: 'completed', completed_steps: [], current_step: null, started_at: null, completed_at: null, review_result: null, retry_count: 0, rollback_context: null },
+        implementation: { status: 'completed', completed_steps: [], current_step: null, started_at: null, completed_at: null, review_result: null, retry_count: 0, rollback_context: null },
+        test_implementation: { status: 'completed', completed_steps: [], current_step: null, started_at: null, completed_at: null, review_result: null, retry_count: 0, rollback_context: null },
+        testing: { status: 'completed', completed_steps: [], current_step: null, started_at: null, completed_at: null, review_result: null, retry_count: 0, rollback_context: null },
+        documentation: { status: 'completed', completed_steps: [], current_step: null, started_at: null, completed_at: null, review_result: null, retry_count: 0, rollback_context: null },
+        report: { status: 'completed', completed_steps: [], current_step: null, started_at: null, completed_at: null, review_result: null, retry_count: 0, rollback_context: null },
+        evaluation: { status: 'completed', completed_steps: [], current_step: null, started_at: null, completed_at: null, review_result: null, retry_count: 0, rollback_context: null },
+      },
+      github_integration: { progress_comment_url: null },
+      costs: { total_input_tokens: 0, total_output_tokens: 0, total_cost_usd: 0 },
+      design_decisions: {},
+      model_config: null,
+      difficulty_analysis: null,
+      rollback_history: [],
+    };
+
+    // 実ファイルを作成
+    fs.writeJsonSync(testMetadataPath, metadataData, { spaces: 2 });
+  });
+
+  afterEach(() => {
+    // テスト後にクリーンアップ
+    if (fs.existsSync(testWorkflowDir)) {
+      fs.removeSync(testWorkflowDir);
+    }
   });
 
   // =============================================================================
@@ -223,14 +279,6 @@ describe('Finalize コマンド - プレビューモード（previewFinalize）'
         skipPrUpdate: false,
         baseBranch: 'main',
       };
-
-      fsMock.readFileSync.mockReturnValue(
-        JSON.stringify({
-          issue_number: '123',  // string型
-          base_commit: 'abc123',
-          phases: {},
-        }) as any
-      );
 
       // When: ドライランモードで実行
       const { handleFinalizeCommand } = await import('../../../src/commands/finalize.js');
@@ -255,14 +303,6 @@ describe('Finalize コマンド - プレビューモード（previewFinalize）'
         baseBranch: 'main',
       };
 
-      fsMock.readFileSync.mockReturnValue(
-        JSON.stringify({
-          issue_number: '123',  // string型
-          base_commit: 'abc123',
-          phases: {},
-        }) as any
-      );
-
       // When & Then: スキップオプションが反映される
       const { handleFinalizeCommand } = await import('../../../src/commands/finalize.js');
       await expect(handleFinalizeCommand(options)).resolves.not.toThrow();
@@ -271,16 +311,52 @@ describe('Finalize コマンド - プレビューモード（previewFinalize）'
 });
 
 describe('Finalize コマンド - エラーケース', () => {
-  const testMetadataPath = '/test/.ai-workflow/issue-123/metadata.json';
+  const testWorkflowDir = path.join(process.cwd(), '.ai-workflow', 'issue-123');
+  const testMetadataPath = path.join(testWorkflowDir, 'metadata.json');
 
   beforeEach(() => {
     jest.clearAllMocks();
 
-    // findWorkflowMetadataのモック設定
-    (findWorkflowMetadata as jest.MockedFunction<typeof findWorkflowMetadata>).mockResolvedValue({
-      repoRoot: '/test/repo',
-      metadataPath: testMetadataPath,
-    });
+    // 実ファイルシステムを使用
+    fs.ensureDirSync(path.dirname(testMetadataPath));
+
+    const metadataData = {
+      issue_number: '123',
+      // base_commit が存在しない（意図的にエラーを発生させる）
+      issue_url: '',
+      issue_title: '',
+      created_at: '',
+      updated_at: '',
+      current_phase: 'evaluation',
+      phases: {
+        planning: { status: 'completed', completed_steps: [], current_step: null, started_at: null, completed_at: null, review_result: null, retry_count: 0, rollback_context: null },
+        requirements: { status: 'completed', completed_steps: [], current_step: null, started_at: null, completed_at: null, review_result: null, retry_count: 0, rollback_context: null },
+        design: { status: 'completed', completed_steps: [], current_step: null, started_at: null, completed_at: null, review_result: null, retry_count: 0, rollback_context: null },
+        test_scenario: { status: 'completed', completed_steps: [], current_step: null, started_at: null, completed_at: null, review_result: null, retry_count: 0, rollback_context: null },
+        implementation: { status: 'completed', completed_steps: [], current_step: null, started_at: null, completed_at: null, review_result: null, retry_count: 0, rollback_context: null },
+        test_implementation: { status: 'completed', completed_steps: [], current_step: null, started_at: null, completed_at: null, review_result: null, retry_count: 0, rollback_context: null },
+        testing: { status: 'completed', completed_steps: [], current_step: null, started_at: null, completed_at: null, review_result: null, retry_count: 0, rollback_context: null },
+        documentation: { status: 'completed', completed_steps: [], current_step: null, started_at: null, completed_at: null, review_result: null, retry_count: 0, rollback_context: null },
+        report: { status: 'completed', completed_steps: [], current_step: null, started_at: null, completed_at: null, review_result: null, retry_count: 0, rollback_context: null },
+        evaluation: { status: 'completed', completed_steps: [], current_step: null, started_at: null, completed_at: null, review_result: null, retry_count: 0, rollback_context: null },
+      },
+      github_integration: { progress_comment_url: null },
+      costs: { total_input_tokens: 0, total_output_tokens: 0, total_cost_usd: 0 },
+      design_decisions: {},
+      model_config: null,
+      difficulty_analysis: null,
+      rollback_history: [],
+    };
+
+    // 実ファイルを作成
+    fs.writeJsonSync(testMetadataPath, metadataData, { spaces: 2 });
+  });
+
+  afterEach(() => {
+    // テスト後にクリーンアップ
+    if (fs.existsSync(testWorkflowDir)) {
+      fs.removeSync(testWorkflowDir);
+    }
   });
 
   // =============================================================================
@@ -288,15 +364,7 @@ describe('Finalize コマンド - エラーケース', () => {
   // =============================================================================
   describe('UC-02: finalize_異常系_base_commit不在', () => {
     test('base_commit が存在しない場合にエラーが発生する', async () => {
-      // Given: base_commit が存在しない
-      fsMock.readFileSync.mockReturnValue(
-        JSON.stringify({
-          issue_number: '123',  // string型
-          // base_commit が存在しない
-          phases: {},
-        }) as any
-      );
-
+      // Given: base_commit が存在しない（beforeEachで意図的に省略）
       const options: FinalizeCommandOptions = {
         issue: '123',
         dryRun: false,
@@ -315,37 +383,52 @@ describe('Finalize コマンド - エラーケース', () => {
 });
 
 describe('Finalize コマンド - CLIオプション挙動検証', () => {
-  const testWorkflowDir = '/test/.ai-workflow/issue-123';
+  const testWorkflowDir = path.join(process.cwd(), '.ai-workflow', 'issue-123');
   const testMetadataPath = path.join(testWorkflowDir, 'metadata.json');
 
   beforeEach(() => {
     jest.clearAllMocks();
-    fsMock.existsSync.mockReturnValue(true);
 
-    // findWorkflowMetadataのモック設定
-    (findWorkflowMetadata as jest.MockedFunction<typeof findWorkflowMetadata>).mockResolvedValue({
-      repoRoot: '/test/repo',
-      metadataPath: testMetadataPath,
-    });
+    // 実ファイルシステムを使用
+    fs.ensureDirSync(path.dirname(testMetadataPath));
 
-    fsMock.readFileSync.mockReturnValue(
-      JSON.stringify({
-        issue_number: '123',  // string型
-        base_commit: 'abc123def456',
-        phases: {
-          planning: { status: 'completed' },
-          requirements: { status: 'completed' },
-          design: { status: 'completed' },
-          test_scenario: { status: 'completed' },
-          implementation: { status: 'completed' },
-          test_implementation: { status: 'completed' },
-          testing: { status: 'completed' },
-          documentation: { status: 'completed' },
-          report: { status: 'completed' },
-          evaluation: { status: 'completed' },
-        },
-      })
-    );
+    const metadataData = {
+      issue_number: '123',
+      base_commit: 'abc123def456',
+      issue_url: '',
+      issue_title: '',
+      created_at: '',
+      updated_at: '',
+      current_phase: 'evaluation',
+      phases: {
+        planning: { status: 'completed', completed_steps: [], current_step: null, started_at: null, completed_at: null, review_result: null, retry_count: 0, rollback_context: null },
+        requirements: { status: 'completed', completed_steps: [], current_step: null, started_at: null, completed_at: null, review_result: null, retry_count: 0, rollback_context: null },
+        design: { status: 'completed', completed_steps: [], current_step: null, started_at: null, completed_at: null, review_result: null, retry_count: 0, rollback_context: null },
+        test_scenario: { status: 'completed', completed_steps: [], current_step: null, started_at: null, completed_at: null, review_result: null, retry_count: 0, rollback_context: null },
+        implementation: { status: 'completed', completed_steps: [], current_step: null, started_at: null, completed_at: null, review_result: null, retry_count: 0, rollback_context: null },
+        test_implementation: { status: 'completed', completed_steps: [], current_step: null, started_at: null, completed_at: null, review_result: null, retry_count: 0, rollback_context: null },
+        testing: { status: 'completed', completed_steps: [], current_step: null, started_at: null, completed_at: null, review_result: null, retry_count: 0, rollback_context: null },
+        documentation: { status: 'completed', completed_steps: [], current_step: null, started_at: null, completed_at: null, review_result: null, retry_count: 0, rollback_context: null },
+        report: { status: 'completed', completed_steps: [], current_step: null, started_at: null, completed_at: null, review_result: null, retry_count: 0, rollback_context: null },
+        evaluation: { status: 'completed', completed_steps: [], current_step: null, started_at: null, completed_at: null, review_result: null, retry_count: 0, rollback_context: null },
+      },
+      github_integration: { progress_comment_url: null },
+      costs: { total_input_tokens: 0, total_output_tokens: 0, total_cost_usd: 0 },
+      design_decisions: {},
+      model_config: null,
+      difficulty_analysis: null,
+      rollback_history: [],
+    };
+
+    // 実ファイルを作成
+    fs.writeJsonSync(testMetadataPath, metadataData, { spaces: 2 });
+  });
+
+  afterEach(() => {
+    // テスト後にクリーンアップ
+    if (fs.existsSync(testWorkflowDir)) {
+      fs.removeSync(testWorkflowDir);
+    }
   });
 
   // =============================================================================


### PR DESCRIPTION
## Summary
- **rollback.test.ts**: 16/16 passing (converted from fs mocks to real file system)
- **finalize.test.ts**: 12/12 passing (removed mocks, fixed baseBranch validation)
- **Progress**: 140/145 test suites passing (+2 suites, +28 tests)

## Changes

### 1. rollback.test.ts (16/16 passing)
- Removed all fs mocks completely
- Converted all 3 test sections (validation, reason loading, preview) to real file system
- Changed test paths to `process.cwd()/.ai-workflow/issue-90-xxx`
- Created real metadata.json files with `fs.writeJsonSync()`
- Created real reason files for `--reason-file` tests
- Added `afterEach()` cleanup for all sections

### 2. finalize.test.ts (12/12 passing)
- **Removed mocks**: Deleted fs-extra mock and findWorkflowMetadata mock (lines 19-41)
- **Real file system conversion**: All test sections now use real files
- **Path fix**: Changed test directories from `issue-123-preview`, `issue-123-error`, `issue-123-cli` to just `issue-123`
  - This allows `findWorkflowMetadata()` to find test metadata (searches in `process.cwd()/.ai-workflow/issue-{NUM}`)
- **Cleanup**: Added `afterEach()` with `fs.removeSync()` for all test sections

### 3. finalize.ts (baseBranch validation fix)
- **Before**: `if (options.baseBranch && options.baseBranch.trim().length === 0)`
- **After**: `if (options.baseBranch !== undefined && options.baseBranch.trim().length === 0)`
- **Reason**: Empty string `''` is falsy, so original check didn't catch it
- **Fix**: Use `!== undefined` to correctly validate empty strings while allowing undefined

## Root Cause
ESM `import * as fs` creates read-only namespace objects. Jest mocks (`jest.spyOn(fs, 'existsSync')`) don't intercept when implementation uses actual fs-extra imports via `MetadataManager` or `WorkflowState.load()`. Real file system approach is required.

## Test Results
```
PASS tests/unit/commands/rollback.test.ts (16/16 tests)
PASS tests/unit/commands/finalize.test.ts (12/12 tests)
```

**Total**: 140/145 test suites passing (96.6%), 5 remaining

## Remaining Failing Suites
1. execute-command.test.ts (1/13 passing)
2. finalize-command.test.ts (0/18 passing)
3. migrate.test.ts (4/23 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)