### PR TITLE
fix: Fully restore GitHub URLs (Issue #558/#564)

### DIFF
--- a/src/core/secret-masker.ts
+++ b/src/core/secret-masker.ts
@@ -254,7 +254,8 @@ export class SecretMasker {
       return placeholder;
     };
 
-    const githubUrlPattern = /github\.com\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_.-]+)(?:\.git)?/g;
+    // Match GitHub URLs with optional paths (issues, pull, etc.)
+    const githubUrlPattern = /github\.com\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_.-]+)(?:\.git|\/(?:issues|pull)\/\d+)?/g;
     masked = masked.replace(githubUrlPattern, (match, owner, repo) => {
       const placeholder = `__GITHUB_URL_${urlIndex++}__`;
       let preservedMatch = match;

--- a/tests/integration/issue-ai-generator-metadata.test.ts
+++ b/tests/integration/issue-ai-generator-metadata.test.ts
@@ -53,12 +53,12 @@ describe('Integration: IssueAIGenerator metadata masking (Issue #558)', () => {
     };
     const parsedMetadata = JSON.parse(sanitizedPayload.tasks[0].task);
 
-    expect(parsedMetadata.issue_url).toContain('https://');
-    expect(parsedMetadata.issue_url).toContain('/issues/49');
-    expect(parsedMetadata.issue_url).toContain('__GITHUB_URL_');
+    // Issue #558/#564: GitHub URLs should be fully restored (no placeholders)
+    expect(parsedMetadata.issue_url).toBe('https://github.com/tielec/ai-code-companion/issues/49');
+    expect(parsedMetadata.issue_url).not.toContain('__GITHUB_URL_');
     expect(parsedMetadata.issue_url).not.toContain('[REDACTED_TOKEN]');
-    expect(parsedMetadata.pr_url).toContain('https://');
-    expect(parsedMetadata.pr_url).toContain('/pull/51');
+    expect(parsedMetadata.pr_url).toBe('https://github.com/tielec/ai-code-companion/pull/51');
+    expect(parsedMetadata.pr_url).not.toContain('__GITHUB_URL_');
     expect(parsedMetadata.pr_url).not.toContain('[REDACTED_TOKEN]');
     expect(parsedMetadata.design_decisions).toBeTruthy();
     expect(Object.values(parsedMetadata.design_decisions)).toContain(null);

--- a/tests/unit/secret-masker.test.ts
+++ b/tests/unit/secret-masker.test.ts
@@ -232,9 +232,10 @@ describe('Issue #558 metadata preservation', () => {
       'issue_url: https://github.com/tielec/ai-code-companion/issues/49, pr_url: https://github.com/tielec/ai-code-companion/pull/51';
     const masked = metadataMasker.maskObject(input);
 
-    expect(masked).toContain('issue_url: https://');
-    expect(masked).toContain('pr_url: https://');
-    expect(masked).toContain('/issues/49');
+    // Issue #558/#564: URLs should be fully restored (no placeholders)
+    expect(masked).toContain('issue_url: https://github.com/tielec/ai-code-companion/issues/49');
+    expect(masked).toContain('pr_url: https://github.com/tielec/ai-code-companion/pull/51');
+    expect(masked).not.toContain('__GITHUB_URL_');
     expect(masked).not.toContain('[REDACTED_TOKEN]');
   });
 
@@ -244,9 +245,10 @@ describe('Issue #558 metadata preservation', () => {
     const input = `Repository: https://github.com/${longOwner}/${longRepo}/issues/123`;
     const masked = metadataMasker.maskObject(input);
 
-    expect(masked).toContain('https://__GITHUB_URL_');
+    // Issue #558/#564: URLs should be fully restored (no placeholders)
+    expect(masked).toContain(`https://github.com/${longOwner}/${longRepo}/issues/123`);
+    expect(masked).not.toContain('__GITHUB_URL_');
     expect(masked).not.toContain('[REDACTED_TOKEN]');
-    expect(masked).toContain('/issues/123');
   });
 
   test('implementation_strategyキーは colon 付きであればマスキングされない', () => {


### PR DESCRIPTION
Problem:
GitHub URLs were not being fully restored after masking, resulting in placeholder artifacts like "https://__GITHUB_URL_0__/issues/74" instead of complete URLs like "https://github.com/owner/repo/issues/74".

Root Cause:
The GitHub URL regex pattern only matched "github.com/owner/repo" without capturing the path segments (/issues/N, /pull/N). During restoration, only the base URL was reconstructed, leaving placeholders in the output.

Solution:
1. Enhanced GitHub URL regex to capture optional paths (/issues/N, /pull/N)
2. Updated test expectations to verify full URL restoration (no placeholders)

Changes:
1. src/core/secret-masker.ts:258
   - Before: /github\.com\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_.-]+)(?:\.git)?/g
   - After:  /github\.com\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_.-]+)(?:\.git|\/(?:issues|pull)\/\d+)?/g
   - Now captures full URLs including /issues/N and /pull/N paths

2. tests/unit/secret-masker.test.ts
   - Changed: expect(masked).toContain('__GITHUB_URL_')
   - To: expect(masked).not.toContain('__GITHUB_URL_')
   - Verify complete URL restoration without placeholders

3. tests/integration/issue-ai-generator-metadata.test.ts
   - Changed: expect(parsedMetadata.issue_url).toContain('__GITHUB_URL_')
   - To: expect(parsedMetadata.issue_url).not.toContain('__GITHUB_URL_')
   - Verify exact URL matches

Test Results:
✅ Test Suites: 2 passed, 2 total
✅ Tests: 39 passed, 39 total

Before:
"issue_url": "https://__GITHUB_URL_0__/issues/74"
"pr_url": "https://__GITHUB_URL_2__/pull/76"

After:
"issue_url": "https://github.com/tielec/ai-code-companion/issues/74" "pr_url": "https://github.com/tielec/ai-code-companion/pull/76"

Fixes #558, #564