### PR TITLE
fix: auto_close_issue ジョブの DRY_RUN デフォルト値を false に変更

### DIFF
--- a/jenkins/jobs/dsl/ai-workflow/ai_workflow_auto_close_issue_job.groovy
+++ b/jenkins/jobs/dsl/ai-workflow/ai_workflow_auto_close_issue_job.groovy
@@ -44,7 +44,7 @@ def createJob = { String jobName, String descriptionHeader, String gitBranch ->
             |- all: 全カテゴリ
             |
             |## 安全対策
-            |- DRY_RUNデフォルトtrue（誤クローズ防止）
+            |- DRY_RUNデフォルトfalse
             |- EXCLUDE_LABELSで保護ラベルを除外
             |- REQUIRE_APPROVALで追加確認（CIでは非推奨）
             |
@@ -132,13 +132,11 @@ Issue分類カテゴリ
             // ========================================
             // 実行オプション
             // ========================================
-            booleanParam('DRY_RUN', true, '''
-ドライランモード（デフォルト: true）
+            booleanParam('DRY_RUN', false, '''
+ドライランモード（デフォルト: false）
 
 true: Issueをクローズせず、クローズ候補の検出結果のみ表示
 false: 実際にIssueをクローズ
-
-安全のため、デフォルトは true に設定されています。
             '''.stripIndent().trim())
 
             // ========================================

--- a/jenkins/jobs/pipeline/ai-workflow/auto-close-issue/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/auto-close-issue/Jenkinsfile
@@ -13,12 +13,12 @@
  * - EXCLUDE_LABELS: 除外ラベル（カンマ区切り、デフォルト: do-not-close,pinned）
  * - REQUIRE_APPROVAL: 承認要否（デフォルト: false）
  * - AGENT_MODE: エージェントモード（auto/codex/claude、デフォルト: auto）
- * - DRY_RUN: ドライランモード（デフォルト: true）
+ * - DRY_RUN: ドライランモード（デフォルト: false）
  * - LANGUAGE: 出力言語（ja/en、デフォルト: ja）
  *
  * 注意:
  * - REPOS_ROOT配下に対象リポジトリをクローンして実行する（auto_issue同様）
- * - DRY_RUNのデフォルトをtrueとし、安全性を優先
+ * - DRY_RUNのデフォルトはfalse（実際にクローズを実行）
  */
 
 def common
@@ -141,7 +141,7 @@ pipeline {
                         error("DAYS_THRESHOLD must be a positive integer: ${daysThreshold}")
                     }
 
-                    def dryRunDefault = (params.DRY_RUN != null ? params.DRY_RUN : true)
+                    def dryRunDefault = (params.DRY_RUN != null ? params.DRY_RUN : false)
                     def dryRunLabel = dryRunDefault ? ' [DRY RUN]' : ''
                     currentBuild.description = "Auto Close Issue | ${params.AUTO_CLOSE_CATEGORY ?: 'followup'}${dryRunDefault ? ' [DRY RUN]' : ''} | ${env.REPO_OWNER}/${env.REPO_NAME}"
 
@@ -182,7 +182,7 @@ pipeline {
                     echo "========================================="
                     echo "Stage: Execute Auto Close Issue"
                     echo "========================================="
-                    def dryRunDefault = (params.DRY_RUN != null ? params.DRY_RUN : true)
+                    def dryRunDefault = (params.DRY_RUN != null ? params.DRY_RUN : false)
                     echo "Category: ${params.AUTO_CLOSE_CATEGORY ?: 'followup'}"
                     echo "Limit: ${params.AUTO_CLOSE_LIMIT ?: '10'}"
                     echo "Confidence Threshold: ${params.CONFIDENCE_THRESHOLD ?: '0.7'}"
@@ -231,7 +231,7 @@ pipeline {
                 echo "Post Processing"
                 echo "========================================="
 
-                def dryRunDefault = (params.DRY_RUN != null ? params.DRY_RUN : true)
+                def dryRunDefault = (params.DRY_RUN != null ? params.DRY_RUN : false)
                 def dryRunLabel = dryRunDefault ? ' [DRY RUN]' : ''
                 currentBuild.description = "Auto Close Issue | ${params.AUTO_CLOSE_CATEGORY ?: 'followup'}${dryRunDefault ? ' [DRY RUN]' : ''} | ${env.REPO_OWNER}/${env.REPO_NAME}"
 
@@ -263,7 +263,7 @@ pipeline {
                 echo "========================================="
                 echo "Repository: ${params.GITHUB_REPOSITORY}"
                 echo "Category: ${params.AUTO_CLOSE_CATEGORY ?: 'followup'}"
-                def dryRunDefault = (params.DRY_RUN != null ? params.DRY_RUN : true)
+                def dryRunDefault = (params.DRY_RUN != null ? params.DRY_RUN : false)
                 def dryRunNote = dryRunDefault ? ' (dry run mode, no issues closed)' : ''
                 echo "Result: Auto close issue completed${dryRunNote}"
 

--- a/tests/integration/jenkins/auto-close-issue-jenkinsfile.test.ts
+++ b/tests/integration/jenkins/auto-close-issue-jenkinsfile.test.ts
@@ -89,7 +89,7 @@ describe('Integration: auto-close-issue Jenkinsfile / Job DSL (Issue #652)', () 
     expect(jobDslContent).toMatch(/stringParam\('CONFIDENCE_THRESHOLD'\s*,\s*'0\.7'/);
     expect(jobDslContent).toMatch(/stringParam\('DAYS_THRESHOLD'\s*,\s*'90'/);
     expect(jobDslContent).toMatch(/stringParam\('EXCLUDE_LABELS'\s*,\s*'do-not-close,pinned'/);
-    expect(jobDslContent).toMatch(/booleanParam\('DRY_RUN'\s*,\s*true/);
+    expect(jobDslContent).toMatch(/booleanParam\('DRY_RUN'\s*,\s*false/);
     expect(jobDslContent).toMatch(/booleanParam\('REQUIRE_APPROVAL'\s*,\s*false/);
     expect(jobDslContent).toMatch(/choiceParam\('LANGUAGE'[\s\S]*'ja'[\s\S]*'en'/);
   });

--- a/tests/integration/jenkins/auto-close-issue-job-config.test.ts
+++ b/tests/integration/jenkins/auto-close-issue-job-config.test.ts
@@ -130,7 +130,7 @@ describe('Integration: auto-close-issue job-config entry (Issue #678)', () => {
     expect(findDef('DAYS_THRESHOLD')?.defaultValue).toBe('90');
     expect(findDef('EXCLUDE_LABELS')?.defaultValue).toBe('do-not-close,pinned');
     expect(findDef('REQUIRE_APPROVAL')?.defaultValue).toBe(false);
-    expect(findDef('DRY_RUN')?.defaultValue).toBe(true);
+    expect(findDef('DRY_RUN')?.defaultValue).toBe(false);
     expect(findDef('COST_LIMIT_USD')?.defaultValue).toBe('10');
 
     expect(findDef('LOG_LEVEL')?.kind).toBe('choice');


### PR DESCRIPTION
DRY_RUN パラメータのデフォルトを true から false に変更し、
ジョブ実行で即座に Issue をクローズするようにした。
DSL、Jenkinsfile のフォールバック値・コメント、関連テストを同期更新。

https://claude.ai/code/session_01F5ZZaRCdU9Fgk7QSkHBN7X