### PR TITLE
fix: post ブロックの node コンテキスト消失エラーを修正

### DIFF
--- a/jenkins/jobs/pipeline/ai-workflow/auto-close-issue/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/auto-close-issue/Jenkinsfile
@@ -234,25 +234,29 @@ pipeline {
                 def dryRunDefault = (params.DRY_RUN != null ? params.DRY_RUN : false)
                 def dryRunLabel = dryRunDefault ? ' [DRY RUN]' : ''
                 currentBuild.description = "Auto Close Issue | ${params.AUTO_CLOSE_CATEGORY ?: 'followup'}${dryRunDefault ? ' [DRY RUN]' : ''} | ${env.REPO_OWNER}/${env.REPO_NAME}"
+            }
+            // node ブロックでノードコンテキストを確保（Docker エージェント消失時の対策）
+            node('ec2-fleet-micro') {
+                script {
+                    archiveArtifacts artifacts: 'auto-close-issue-results.json', allowEmptyArchive: true
 
-                archiveArtifacts artifacts: 'auto-close-issue-results.json', allowEmptyArchive: true
+                    if (env.REPOS_ROOT) {
+                        sh """
+                            rm -rf ${env.REPOS_ROOT}
+                        """
+                        echo "REPOS_ROOT cleaned up: ${env.REPOS_ROOT}"
+                    }
 
-                if (env.REPOS_ROOT) {
-                    sh """
-                        rm -rf ${env.REPOS_ROOT}
-                    """
-                    echo "REPOS_ROOT cleaned up: ${env.REPOS_ROOT}"
+                    if (env.CODEX_HOME?.trim()) {
+                        sh """
+                            rm -rf ${env.CODEX_HOME}
+                        """
+                        echo "CODEX_HOME cleaned up: ${env.CODEX_HOME}"
+                    }
+
+                    cleanWs()
+                    echo "Workspace cleaned up"
                 }
-
-                if (env.CODEX_HOME?.trim()) {
-                    sh """
-                        rm -rf ${env.CODEX_HOME}
-                    """
-                    echo "CODEX_HOME cleaned up: ${env.CODEX_HOME}"
-                }
-
-                cleanWs()
-                echo "Workspace cleaned up"
             }
         }
 

--- a/jenkins/jobs/pipeline/ai-workflow/rewrite-issue/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/rewrite-issue/Jenkinsfile
@@ -211,23 +211,27 @@ pipeline {
                 def applyLabel = params.APPLY ? ' [APPLY]' : ''
                 def dryRunLabel = (!params.APPLY && params.DRY_RUN) ? ' [DRY RUN]' : ''
                 currentBuild.description = "Rewrite Issue #${env.ISSUE_NUMBER}${applyLabel}${dryRunLabel} | ${env.REPO_OWNER}/${env.REPO_NAME}"
+            }
+            // node ブロックでノードコンテキストを確保（Docker エージェント消失時の対策）
+            node('ec2-fleet-micro') {
+                script {
+                    if (env.REPOS_ROOT) {
+                        sh """
+                            rm -rf ${env.REPOS_ROOT}
+                        """
+                        echo "REPOS_ROOT cleaned up: ${env.REPOS_ROOT}"
+                    }
 
-                if (env.REPOS_ROOT) {
-                    sh """
-                        rm -rf ${env.REPOS_ROOT}
-                    """
-                    echo "REPOS_ROOT cleaned up: ${env.REPOS_ROOT}"
+                    if (env.CODEX_HOME?.trim()) {
+                        sh """
+                            rm -rf ${env.CODEX_HOME}
+                        """
+                        echo "CODEX_HOME cleaned up: ${env.CODEX_HOME}"
+                    }
+
+                    cleanWs()
+                    echo "Workspace cleaned up"
                 }
-
-                if (env.CODEX_HOME?.trim()) {
-                    sh """
-                        rm -rf ${env.CODEX_HOME}
-                    """
-                    echo "CODEX_HOME cleaned up: ${env.CODEX_HOME}"
-                }
-
-                cleanWs()
-                echo "Workspace cleaned up"
             }
         }
 


### PR DESCRIPTION
Docker エージェントが消失した場合、post ブロック内の sh/cleanWs/archiveArtifacts がノードコンテキストなしで実行されて agent none エラーが発生していた。
node('ec2-fleet-micro') ブロックで囲むことでノードを確保。

https://claude.ai/code/session_01F5ZZaRCdU9Fgk7QSkHBN7X