### PR TITLE
fix: resolve-conflict Job DSL の scriptPath を修正

### DIFF
--- a/jenkins/jobs/dsl/ai-workflow/ai_workflow_resolve_conflict_job.groovy
+++ b/jenkins/jobs/dsl/ai-workflow/ai_workflow_resolve_conflict_job.groovy
@@ -205,7 +205,7 @@ X-Webhook-Tokenヘッダーとして送信されます。
                         branch(gitBranch)
                     }
                 }
-                scriptPath('jenkins/jobs/pipeline/ai-workflow/resolve-conflict/Jenkinsfile_WRONG')
+                scriptPath('jenkins/jobs/pipeline/ai-workflow/resolve-conflict/Jenkinsfile')
             }
         }
 


### PR DESCRIPTION
scriptPath が 'Jenkinsfile_WRONG' になっていたのを正しい 'Jenkinsfile' に修正。