### PR TITLE
fix: execute フェーズで head ブランチ上にマージコミットを作成する

### DIFF
--- a/src/commands/resolve-conflict/execute.ts
+++ b/src/commands/resolve-conflict/execute.ts
@@ -83,6 +83,7 @@ export async function handleResolveConflictExecuteCommand(options: ResolveConfli
       process.exit(1);
     }
 
+    // Step 1: Load metadata and plan before branch switch
     const metadata = await metadataManager.getMetadata();
     if (!metadata.resolutionPlanPath) {
       throw new Error('Resolution plan not found. Run analyze first.');
@@ -90,29 +91,87 @@ export async function handleResolveConflictExecuteCommand(options: ResolveConfli
 
     const plan = await loadResolutionPlan(metadata.resolutionPlanPath);
 
+    const baseBranch = metadata.baseBranch;
+    const headBranch = metadata.headBranch;
+    if (!baseBranch || !headBranch) {
+      throw new Error('Base or head branch not found in metadata. Run analyze first.');
+    }
+
+    // Step 2: Resolve conflicts (agent call if needed)
     const resolver = new ConflictResolver(repoRoot);
     const resolutions = await resolver.resolve(plan, {
       agent: options.agent ?? 'auto',
       language: options.language === 'en' ? 'en' : 'ja',
     });
 
+    // Step 3: Git setup and branch preparation
+    const git = simpleGit(repoRoot);
+    await ensureGitConfig(git);
+    await git.fetch('origin', baseBranch);
+    await git.fetch('origin', headBranch);
+
+    const currentStatus = await git.status();
+    const originalBranch = currentStatus.current ?? 'HEAD';
+
+    const locals = await git.branchLocal();
+    if (locals.all.includes(headBranch)) {
+      await git.checkout(headBranch);
+    } else {
+      await git.checkoutBranch(headBranch, `origin/${headBranch}`);
+    }
+
+    // Step 4: Merge base branch (conflicts are expected)
+    let mergeStarted = false;
+    try {
+      await git.raw(['merge', '--no-commit', '--no-ff', `origin/${baseBranch}`]);
+      mergeStarted = true;
+      logger.info('Merge completed without conflicts.');
+    } catch (mergeError: unknown) {
+      const mergeStatus = await git.status();
+      if (mergeStatus.conflicted && mergeStatus.conflicted.length > 0) {
+        mergeStarted = true;
+        logger.info(`Merge conflicts detected (${mergeStatus.conflicted.length} files). Applying resolutions.`);
+      } else {
+        throw new Error(`Merge failed unexpectedly: ${getErrorMessage(mergeError)}`);
+      }
+    }
+
+    // Step 5: Apply resolved content
     const applier = new CodeChangeApplier(repoRoot);
-    const changes = resolutions.map((resolution) => ({
-      path: resolution.filePath,
+    const changes = resolutions.map((r) => ({
+      path: r.filePath,
       change_type: 'modify' as const,
-      content: resolution.resolvedContent,
+      content: r.resolvedContent,
     }));
 
     const applyResult = await applier.apply(changes, options.dryRun ?? false);
     if (!applyResult.success) {
+      if (mergeStarted) {
+        try { await git.raw(['merge', '--abort']); } catch { /* ignore */ }
+      }
       throw new Error(applyResult.error ?? 'Failed to apply resolved changes');
     }
 
     if (options.dryRun) {
+      if (mergeStarted) {
+        try { await git.raw(['merge', '--abort']); } catch { /* ignore */ }
+      }
+      await git.checkout(originalBranch);
       logger.info('[DRY-RUN] Changes preview completed. No files were modified.');
       return;
     }
 
+    // Step 6: Create merge commit
+    await git.add(resolutions.map((r) => r.filePath));
+    const commitStatus = await git.status();
+    if (commitStatus.files.length > 0) {
+      await git.commit(`[resolve-conflict] Resolve merge conflicts for PR #${prInfo.prNumber}`);
+      logger.info(`Created merge commit for PR #${prInfo.prNumber}`);
+    } else {
+      logger.info('No file changes to commit.');
+    }
+
+    // Step 7: Save artifacts and update metadata
     const outputDir = path.join(repoRoot, '.ai-workflow', `conflict-${prInfo.prNumber}`);
     await fsp.mkdir(outputDir, { recursive: true });
 
@@ -122,16 +181,6 @@ export async function handleResolveConflictExecuteCommand(options: ResolveConfli
     await fsp.writeFile(resultJsonPath, JSON.stringify(resolutions, null, 2), 'utf-8');
     await fsp.writeFile(resultMdPath, buildResolutionResultMarkdown(resolutions, resultJsonPath), 'utf-8');
 
-    const git = simpleGit(repoRoot);
-    await ensureGitConfig(git);
-    await git.add(resolutions.map((resolution) => resolution.filePath));
-    const status = await git.status();
-    if (status.files.length > 0) {
-      await git.commit(`[resolve-conflict] Resolve conflicts for PR #${prInfo.prNumber}`);
-    } else {
-      logger.info('No file changes to commit.');
-    }
-
     await metadataManager.setResolutionResult(resultMdPath);
     await metadataManager.updateStatus('executed');
 
@@ -139,7 +188,6 @@ export async function handleResolveConflictExecuteCommand(options: ResolveConfli
       const workflowDir = path.join('.ai-workflow', `conflict-${prInfo.prNumber}`);
       await git.add(path.join(workflowDir, '*'));
       await git.commit(`resolve-conflict: execute artifacts for PR #${prInfo.prNumber}`);
-      logger.info(`Committed execute artifacts for PR #${prInfo.prNumber}`);
     } catch (commitError: unknown) {
       logger.warn(`Failed to commit execute artifacts: ${getErrorMessage(commitError)}`);
     }

--- a/tests/integration/commands/resolve-conflict.test.ts
+++ b/tests/integration/commands/resolve-conflict.test.ts
@@ -162,8 +162,21 @@ describe('resolve-conflict コマンド統合テスト', () => {
     };
 
     const gitExecute = {
+      fetch: jest.fn().mockResolvedValue(undefined),
+      status: jest.fn()
+        .mockResolvedValueOnce({ current: 'develop', files: [], conflicted: [] })
+        .mockResolvedValueOnce({ current: 'feature', files: [], conflicted: ['src/conflict.ts'] })
+        .mockResolvedValueOnce({ files: [{ path: 'src/conflict.ts' }], current: 'feature' }),
+      branchLocal: jest.fn().mockResolvedValue({ all: ['main', 'feature'] }),
+      checkout: jest.fn().mockResolvedValue(undefined),
+      checkoutBranch: jest.fn().mockResolvedValue(undefined),
+      raw: jest.fn().mockImplementation((args: string[]) => {
+        if (args[0] === 'merge' && args[1] === '--no-commit') {
+          throw new Error('merge conflict');
+        }
+        return Promise.resolve('');
+      }),
       add: jest.fn().mockResolvedValue(undefined),
-      status: jest.fn().mockResolvedValue({ files: [{ path: 'src/conflict.ts' }], current: 'feature' }),
       commit: jest.fn().mockResolvedValue(undefined),
     };
 
@@ -253,7 +266,25 @@ describe('resolve-conflict コマンド統合テスト', () => {
       commit: jest.fn().mockResolvedValue(undefined),
     };
 
-    const gitInstances = [gitInit, gitAnalyze];
+    const gitExecute = {
+      fetch: jest.fn().mockResolvedValue(undefined),
+      status: jest.fn()
+        .mockResolvedValueOnce({ current: 'develop', files: [], conflicted: [] })
+        .mockResolvedValueOnce({ current: 'feature', files: [], conflicted: ['src/conflict.ts'] }),
+      branchLocal: jest.fn().mockResolvedValue({ all: ['main', 'feature'] }),
+      checkout: jest.fn().mockResolvedValue(undefined),
+      checkoutBranch: jest.fn().mockResolvedValue(undefined),
+      raw: jest.fn().mockImplementation((args: string[]) => {
+        if (args[0] === 'merge' && args[1] === '--no-commit') {
+          throw new Error('merge conflict');
+        }
+        return Promise.resolve('');
+      }),
+      add: jest.fn().mockResolvedValue(undefined),
+      commit: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const gitInstances = [gitInit, gitAnalyze, gitExecute];
     simpleGitMock.mockImplementation(() => gitInstances.shift());
 
     await handleResolveConflictInitCommand({ prUrl, language: 'ja' });
@@ -266,6 +297,11 @@ describe('resolve-conflict コマンド統合テスト', () => {
     const outputDir = path.join(repoRoot, '.ai-workflow', 'conflict-42');
     await expect(fsp.access(path.join(outputDir, 'resolution-result.json'))).rejects.toThrow();
     await expect(fsp.access(path.join(outputDir, 'resolution-result.md'))).rejects.toThrow();
+
+    // merge --abort が呼ばれ、元のブランチに戻る
+    expect(gitExecute.raw).toHaveBeenCalledWith(['merge', '--abort']);
+    expect(gitExecute.checkout).toHaveBeenCalledWith('develop');
+    expect(gitExecute.commit).not.toHaveBeenCalled();
   });
 
   it('analyze_コンフリクト無し_早期終了して計画を作成しない', async () => {
@@ -615,8 +651,21 @@ describe('resolve-conflict コマンド統合テスト', () => {
     };
 
     const gitExecute = {
+      fetch: jest.fn().mockResolvedValue(undefined),
+      status: jest.fn()
+        .mockResolvedValueOnce({ current: 'develop', files: [], conflicted: [] })
+        .mockResolvedValueOnce({ current: 'feature', files: [], conflicted: ['src/conflict.ts'] })
+        .mockResolvedValueOnce({ files: [{ path: 'src/conflict.ts' }], current: 'feature' }),
+      branchLocal: jest.fn().mockResolvedValue({ all: ['main', 'feature'] }),
+      checkout: jest.fn().mockResolvedValue(undefined),
+      checkoutBranch: jest.fn().mockResolvedValue(undefined),
+      raw: jest.fn().mockImplementation((args: string[]) => {
+        if (args[0] === 'merge' && args[1] === '--no-commit') {
+          throw new Error('merge conflict');
+        }
+        return Promise.resolve('');
+      }),
       add: jest.fn().mockResolvedValue(undefined),
-      status: jest.fn().mockResolvedValue({ files: [{ path: 'src/conflict.ts' }], current: 'feature' }),
       commit: jest.fn().mockResolvedValue(undefined),
     };
 
@@ -1039,8 +1088,21 @@ describe('resolve-conflict コマンド統合テスト', () => {
     };
 
     const gitExecute = {
+      fetch: jest.fn().mockResolvedValue(undefined),
+      status: jest.fn()
+        .mockResolvedValueOnce({ current: 'develop', files: [], conflicted: [] })
+        .mockResolvedValueOnce({ current: 'feature', files: [], conflicted: ['src/conflict.ts'] })
+        .mockResolvedValueOnce({ files: [{ path: 'src/conflict.ts' }], current: 'feature' }),
+      branchLocal: jest.fn().mockResolvedValue({ all: ['main', 'feature'] }),
+      checkout: jest.fn().mockResolvedValue(undefined),
+      checkoutBranch: jest.fn().mockResolvedValue(undefined),
+      raw: jest.fn().mockImplementation((args: string[]) => {
+        if (args[0] === 'merge' && args[1] === '--no-commit') {
+          throw new Error('merge conflict');
+        }
+        return Promise.resolve('');
+      }),
       add: jest.fn().mockResolvedValue(undefined),
-      status: jest.fn().mockResolvedValue({ files: [{ path: 'src/conflict.ts' }], current: 'feature' }),
       commit: jest.fn().mockResolvedValue(undefined),
     };
 
@@ -1118,8 +1180,21 @@ describe('resolve-conflict コマンド統合テスト', () => {
     };
 
     const gitExecute = {
+      fetch: jest.fn().mockResolvedValue(undefined),
+      status: jest.fn()
+        .mockResolvedValueOnce({ current: 'develop', files: [], conflicted: [] })
+        .mockResolvedValueOnce({ current: 'feature', files: [], conflicted: ['src/conflict.ts'] })
+        .mockResolvedValueOnce({ files: [{ path: 'src/conflict.ts' }], current: 'feature' }),
+      branchLocal: jest.fn().mockResolvedValue({ all: ['main', 'feature'] }),
+      checkout: jest.fn().mockResolvedValue(undefined),
+      checkoutBranch: jest.fn().mockResolvedValue(undefined),
+      raw: jest.fn().mockImplementation((args: string[]) => {
+        if (args[0] === 'merge' && args[1] === '--no-commit') {
+          throw new Error('merge conflict');
+        }
+        return Promise.resolve('');
+      }),
       add: jest.fn().mockResolvedValue(undefined),
-      status: jest.fn().mockResolvedValue({ files: [{ path: 'src/conflict.ts' }], current: 'feature' }),
       commit: jest.fn()
         .mockResolvedValueOnce(undefined)
         .mockRejectedValueOnce(new Error('nothing to commit')),
@@ -1199,8 +1274,21 @@ describe('resolve-conflict コマンド統合テスト', () => {
     };
 
     const gitExecute = {
+      fetch: jest.fn().mockResolvedValue(undefined),
+      status: jest.fn()
+        .mockResolvedValueOnce({ current: 'develop', files: [], conflicted: [] })
+        .mockResolvedValueOnce({ current: 'feature', files: [], conflicted: ['src/conflict.ts'] })
+        .mockResolvedValueOnce({ files: [{ path: 'src/conflict.ts' }], current: 'feature' }),
+      branchLocal: jest.fn().mockResolvedValue({ all: ['main', 'feature'] }),
+      checkout: jest.fn().mockResolvedValue(undefined),
+      checkoutBranch: jest.fn().mockResolvedValue(undefined),
+      raw: jest.fn().mockImplementation((args: string[]) => {
+        if (args[0] === 'merge' && args[1] === '--no-commit') {
+          throw new Error('merge conflict');
+        }
+        return Promise.resolve('');
+      }),
       add: jest.fn().mockResolvedValue(undefined),
-      status: jest.fn().mockResolvedValue({ files: [{ path: 'src/conflict.ts' }], current: 'feature' }),
       commit: jest.fn().mockResolvedValue(undefined),
     };
 


### PR DESCRIPTION
execute フェーズが Jenkins のチェックアウトブランチ上で通常コミットを
作成していたため、PR のコンフリクトが実際には解消されなかった。
head ブランチへの checkout と git merge --no-commit --no-ff による マージコミット作成に修正し、dry-run 時は merge --abort でクリーンアップする。