### PR TITLE
fix: マージ後に常に git status で未マージファイルを検出する

### DIFF
--- a/tests/integration/commands/resolve-conflict.test.ts
+++ b/tests/integration/commands/resolve-conflict.test.ts
@@ -166,6 +166,7 @@ describe('resolve-conflict コマンド統合テスト', () => {
       status: jest.fn()
         .mockResolvedValueOnce({ current: 'develop', files: [], conflicted: [] })
         .mockResolvedValueOnce({ current: 'feature', files: [], conflicted: ['src/conflict.ts'] })
+        .mockResolvedValueOnce({ current: 'feature', files: [], conflicted: [] })
         .mockResolvedValueOnce({ files: [{ path: 'src/conflict.ts' }], current: 'feature' }),
       branchLocal: jest.fn().mockResolvedValue({ all: ['main', 'feature'] }),
       checkout: jest.fn().mockResolvedValue(undefined),
@@ -655,6 +656,7 @@ describe('resolve-conflict コマンド統合テスト', () => {
       status: jest.fn()
         .mockResolvedValueOnce({ current: 'develop', files: [], conflicted: [] })
         .mockResolvedValueOnce({ current: 'feature', files: [], conflicted: ['src/conflict.ts'] })
+        .mockResolvedValueOnce({ current: 'feature', files: [], conflicted: [] })
         .mockResolvedValueOnce({ files: [{ path: 'src/conflict.ts' }], current: 'feature' }),
       branchLocal: jest.fn().mockResolvedValue({ all: ['main', 'feature'] }),
       checkout: jest.fn().mockResolvedValue(undefined),
@@ -1092,6 +1094,7 @@ describe('resolve-conflict コマンド統合テスト', () => {
       status: jest.fn()
         .mockResolvedValueOnce({ current: 'develop', files: [], conflicted: [] })
         .mockResolvedValueOnce({ current: 'feature', files: [], conflicted: ['src/conflict.ts'] })
+        .mockResolvedValueOnce({ current: 'feature', files: [], conflicted: [] })
         .mockResolvedValueOnce({ files: [{ path: 'src/conflict.ts' }], current: 'feature' }),
       branchLocal: jest.fn().mockResolvedValue({ all: ['main', 'feature'] }),
       checkout: jest.fn().mockResolvedValue(undefined),
@@ -1184,6 +1187,7 @@ describe('resolve-conflict コマンド統合テスト', () => {
       status: jest.fn()
         .mockResolvedValueOnce({ current: 'develop', files: [], conflicted: [] })
         .mockResolvedValueOnce({ current: 'feature', files: [], conflicted: ['src/conflict.ts'] })
+        .mockResolvedValueOnce({ current: 'feature', files: [], conflicted: [] })
         .mockResolvedValueOnce({ files: [{ path: 'src/conflict.ts' }], current: 'feature' }),
       branchLocal: jest.fn().mockResolvedValue({ all: ['main', 'feature'] }),
       checkout: jest.fn().mockResolvedValue(undefined),
@@ -1278,6 +1282,7 @@ describe('resolve-conflict コマンド統合テスト', () => {
       status: jest.fn()
         .mockResolvedValueOnce({ current: 'develop', files: [], conflicted: [] })
         .mockResolvedValueOnce({ current: 'feature', files: [], conflicted: ['src/conflict.ts'] })
+        .mockResolvedValueOnce({ current: 'feature', files: [], conflicted: [] })
         .mockResolvedValueOnce({ files: [{ path: 'src/conflict.ts' }], current: 'feature' }),
       branchLocal: jest.fn().mockResolvedValue({ all: ['main', 'feature'] }),
       checkout: jest.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
simple-git の raw() がコンフリクト発生時に例外を投げないケースがあり、
未マージファイルが残ったまま commit を試行してエラーになっていた。
マージコマンドの成否に関わらず常に git status で conflicted を確認し、
解消計画外の未マージファイルも git add するよう修正。