### PR TITLE
fix: createResolutionPlan のバリデーション追加と未解消ファイルのコミット防止

### DIFF
--- a/src/commands/resolve-conflict/execute.ts
+++ b/src/commands/resolve-conflict/execute.ts
@@ -174,8 +174,12 @@ export async function handleResolveConflictExecuteCommand(options: ResolveConfli
     const postAddStatus = await git.status();
     const remainingConflicted = postAddStatus.conflicted ?? [];
     if (remainingConflicted.length > 0) {
-      logger.warn(`Remaining unmerged files not in resolution plan: ${remainingConflicted.join(', ')}. Adding as-is.`);
-      await git.add(remainingConflicted);
+      if (mergeStarted) {
+        try { await git.raw(['merge', '--abort']); } catch { /* ignore */ }
+      }
+      throw new Error(
+        `Remaining unmerged files not in resolution plan: ${remainingConflicted.join(', ')}. Aborting merge to prevent committing conflict markers.`,
+      );
     }
 
     const commitStatus = await git.status();

--- a/src/core/git/conflict-resolver.ts
+++ b/src/core/git/conflict-resolver.ts
@@ -178,6 +178,17 @@ export class ConflictResolver {
       return normalizeResolution(resolution as ConflictResolution, fallbackContent);
     });
 
+    // Validate all conflict files have resolutions
+    const conflictFilePaths = [...new Set(filteredConflicts.map((block) => block.filePath))];
+    const resolvedPaths = new Set(resolutions.map((r) => r.filePath));
+    const missingFiles = conflictFilePaths.filter((fp) => !resolvedPaths.has(fp));
+
+    if (missingFiles.length > 0) {
+      throw new Error(
+        `Resolution plan is incomplete: ${missingFiles.length} conflicted files have no resolution: ${missingFiles.join(', ')}`,
+      );
+    }
+
     return {
       prNumber: options.prNumber,
       baseBranch: options.baseBranch,


### PR DESCRIPTION
- createResolutionPlan() でエージェントの応答が全コンフリクトファイルをカバーしているか検証
- execute フェーズで解消計画にない未マージファイルがある場合 merge --abort してエラーに