### PR TITLE
fix: Escape WORKSPACE variable in create-sub-issue Jenkinsfile docker…

### DIFF
--- a/jenkins/jobs/pipeline/ai-workflow/create-sub-issue/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/create-sub-issue/Jenkinsfile
@@ -32,7 +32,7 @@ pipeline {
             label 'ec2-fleet-micro'
             dir '.'
             filename 'Dockerfile'
-            args "-v ${WORKSPACE}:/workspace -w /workspace -e CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=1"
+            args "-v \${WORKSPACE}:/workspace -w /workspace -e CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=1"
         }
     }
 


### PR DESCRIPTION
… args

Unescaped ${WORKSPACE} was resolved by Groovy at parse time before the node was allocated, causing Docker agent startup failure and subsequent 'agent none' error in post block.