### PR TITLE
fix: all-phases JenkinsfileでローカルDockerビルドからECRイメージに切り替え

### DIFF
--- a/jenkins/jobs/pipeline/ai-workflow/all-phases/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/all-phases/Jenkinsfile
@@ -34,10 +34,9 @@ def common
 
 pipeline {
     agent {
-        dockerfile {
+        docker {
+            image '621593801728.dkr.ecr.ap-northeast-1.amazonaws.com/ai-workflow-agent:latest'
             label 'ec2-fleet-small'
-            dir '.'
-            filename 'Dockerfile'
             args "-v \${WORKSPACE}:/workspace -w /workspace -e CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=1"
         }
     }


### PR DESCRIPTION
毎回のジョブ実行時にDockerfileからビルドする代わりに、
ECRにプッシュ済みのイメージを直接使用するように変更。