### PR TITLE
fix: Docker agent argsからワークスペースマウント指定を削除

### DIFF
--- a/jenkins/jobs/pipeline/ai-workflow/all-phases/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/all-phases/Jenkinsfile
@@ -37,7 +37,7 @@ pipeline {
         docker {
             image '621593801728.dkr.ecr.ap-northeast-1.amazonaws.com/ai-workflow-agent:latest'
             label 'ec2-fleet-small'
-            args "-v \${WORKSPACE}:/workspace -w /workspace -e CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=1"
+            args "-e CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=1"
         }
     }
 


### PR DESCRIPTION
Jenkins docker agentが自動的にワークスペースをマウントするため、
明示的な -v/-w 指定が durable task プラグインと競合していた。