### PR TITLE
fix: postブロックにnodeコンテキストを追加

### DIFF
--- a/jenkins/jobs/pipeline/ai-workflow/all-phases/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/all-phases/Jenkinsfile
@@ -278,35 +278,37 @@ pipeline {
 
     post {
         always {
-            script {
-                echo "========================================="
-                echo "Post Processing"
-                echo "========================================="
+            node('ec2-fleet-small') {
+                script {
+                    echo "========================================="
+                    echo "Post Processing"
+                    echo "========================================="
 
-                currentBuild.description = "Issue #${env.ISSUE_NUMBER} | All Phases | ${env.REPO_OWNER}/${env.REPO_NAME}"
+                    currentBuild.description = "Issue #${env.ISSUE_NUMBER} | All Phases | ${env.REPO_OWNER}/${env.REPO_NAME}"
 
-                if (env.ISSUE_NUMBER && env.ISSUE_NUMBER != 'auto') {
-                    common.archiveArtifacts(env.ISSUE_NUMBER)
+                    if (env.ISSUE_NUMBER && env.ISSUE_NUMBER != 'auto') {
+                        common.archiveArtifacts(env.ISSUE_NUMBER)
+                    }
+
+                    // REPOS_ROOTクリーンアップ
+                    if (env.REPOS_ROOT) {
+                        sh """
+                            rm -rf ${env.REPOS_ROOT}
+                        """
+                        echo "REPOS_ROOT cleaned up: ${env.REPOS_ROOT}"
+                    }
+
+                    if (env.CODEX_HOME?.trim()) {
+                        sh """
+                            rm -rf ${env.CODEX_HOME}
+                        """
+                        echo "CODEX_HOME cleaned up: ${env.CODEX_HOME}"
+                    }
+
+                    // ワークスペースのクリーンアップ
+                    cleanWs()
+                    echo "Workspace cleaned up"
                 }
-
-                // REPOS_ROOTクリーンアップ
-                if (env.REPOS_ROOT) {
-                    sh """
-                        rm -rf ${env.REPOS_ROOT}
-                    """
-                    echo "REPOS_ROOT cleaned up: ${env.REPOS_ROOT}"
-                }
-
-                if (env.CODEX_HOME?.trim()) {
-                    sh """
-                        rm -rf ${env.CODEX_HOME}
-                    """
-                    echo "CODEX_HOME cleaned up: ${env.CODEX_HOME}"
-                }
-
-                // ワークスペースのクリーンアップ
-                cleanWs()
-                echo "Workspace cleaned up"
             }
         }
 


### PR DESCRIPTION
Docker agentの場合、postブロック実行時にコンテナが終了しており
FilePath コンテキストが失われるため、node()で囲んで解消。