### PR TITLE
fix: Docker argsに-u root:rootを追加

### DIFF
--- a/jenkins/jobs/pipeline/ai-workflow/all-phases/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/all-phases/Jenkinsfile
@@ -37,7 +37,7 @@ pipeline {
         docker {
             image '621593801728.dkr.ecr.ap-northeast-1.amazonaws.com/ai-workflow-agent:latest'
             label 'ec2-fleet-small'
-            args "-e CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=1"
+            args "-u root:root -e CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS=1"
         }
     }
 


### PR DESCRIPTION
Jenkins Docker pluginがホストのUID/GIDでコンテナを起動するため、
コンテナ内に該当ユーザーが存在せずdurable taskが起動できなかった。