### PR TITLE
fix: ENTRYPOINTをクリアしJenkins withDockerContainerとの互換性を確保

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,8 @@ RUN npm run build
 # When true, agents can install additional packages as needed
 ENV AGENT_CAN_INSTALL_PACKAGES=true
 
-# Default command opens a shell for interactive usage inside the container.
-# The CLI can be executed via `npm start -- <args>` or `node dist/index.js ...`
+# Jenkins withDockerContainer は `docker run <image> cat` でコンテナを維持し、
+# docker exec で各ステップを実行する。ENTRYPOINT が引数をパススルーしないと
+# cat プロセスが起動せず失敗するため、明示的に設定する。
+ENTRYPOINT []
 CMD ["/bin/bash"]

--- a/jenkins/jobs/pipeline/ai-workflow/all-phases/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/all-phases/Jenkinsfile
@@ -278,37 +278,35 @@ pipeline {
 
     post {
         always {
-            node('ec2-fleet-small') {
-                script {
-                    echo "========================================="
-                    echo "Post Processing"
-                    echo "========================================="
+            script {
+                echo "========================================="
+                echo "Post Processing"
+                echo "========================================="
 
-                    currentBuild.description = "Issue #${env.ISSUE_NUMBER} | All Phases | ${env.REPO_OWNER}/${env.REPO_NAME}"
+                currentBuild.description = "Issue #${env.ISSUE_NUMBER} | All Phases | ${env.REPO_OWNER}/${env.REPO_NAME}"
 
-                    if (env.ISSUE_NUMBER && env.ISSUE_NUMBER != 'auto') {
-                        common.archiveArtifacts(env.ISSUE_NUMBER)
-                    }
-
-                    // REPOS_ROOTクリーンアップ
-                    if (env.REPOS_ROOT) {
-                        sh """
-                            rm -rf ${env.REPOS_ROOT}
-                        """
-                        echo "REPOS_ROOT cleaned up: ${env.REPOS_ROOT}"
-                    }
-
-                    if (env.CODEX_HOME?.trim()) {
-                        sh """
-                            rm -rf ${env.CODEX_HOME}
-                        """
-                        echo "CODEX_HOME cleaned up: ${env.CODEX_HOME}"
-                    }
-
-                    // ワークスペースのクリーンアップ
-                    cleanWs()
-                    echo "Workspace cleaned up"
+                if (env.ISSUE_NUMBER && env.ISSUE_NUMBER != 'auto') {
+                    common.archiveArtifacts(env.ISSUE_NUMBER)
                 }
+
+                // REPOS_ROOTクリーンアップ
+                if (env.REPOS_ROOT) {
+                    sh """
+                        rm -rf ${env.REPOS_ROOT}
+                    """
+                    echo "REPOS_ROOT cleaned up: ${env.REPOS_ROOT}"
+                }
+
+                if (env.CODEX_HOME?.trim()) {
+                    sh """
+                        rm -rf ${env.CODEX_HOME}
+                    """
+                    echo "CODEX_HOME cleaned up: ${env.CODEX_HOME}"
+                }
+
+                // ワークスペースのクリーンアップ
+                cleanWs()
+                echo "Workspace cleaned up"
             }
         }
 


### PR DESCRIPTION
node:20-slimのdocker-entrypoint.shがJenkinsのcatコマンドを パススルーしないためコンテナが即座に終了していた。
ENTRYPOINT []で継承されたENTRYPOINTをクリアし、postブロックも元の形に復元。