### PR TITLE
fix: AWS CLI multi-arch対応とECR credential helper対応

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,14 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
     && apt-get install -y gh \
     && rm -rf /var/lib/apt/lists/*
 
-# Install AWS CLI v2
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+# Install AWS CLI v2 (multi-arch support)
+RUN ARCH=$(uname -m) && \
+    if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then \
+        AWS_CLI_URL="https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"; \
+    else \
+        AWS_CLI_URL="https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"; \
+    fi && \
+    curl "$AWS_CLI_URL" -o "awscliv2.zip" && \
     unzip awscliv2.zip && \
     ./aws/install && \
     rm -rf aws awscliv2.zip

--- a/jenkins/jobs/pipeline/ai-workflow/ecr-verify/Jenkinsfile
+++ b/jenkins/jobs/pipeline/ai-workflow/ecr-verify/Jenkinsfile
@@ -87,29 +87,23 @@ pipeline {
             }
         }
 
-        stage('ECR Login') {
+        stage('Verify ECR Credential Helper') {
             steps {
                 script {
                     echo "========================================="
-                    echo "Stage: ECR Login"
+                    echo "Stage: Verify ECR Credential Helper"
                     echo "========================================="
 
-                    def loginResult = sh(
-                        script: """
-                            aws ecr get-login-password \
-                                --region ${env.AWS_REGION_VALUE} \
-                            | docker login \
-                                --username AWS \
-                                --password-stdin ${env.ECR_REGISTRY}
-                        """,
+                    def helperResult = sh(
+                        script: "docker-credential-ecr-login version",
                         returnStatus: true
                     )
 
-                    if (loginResult != 0) {
-                        error("ECRログインに失敗しました。AWSリージョン: ${env.AWS_REGION_VALUE}, アカウントID: ${env.AWS_ACCOUNT_ID_VALUE}")
+                    if (helperResult != 0) {
+                        error("ECR credential helper が見つかりません。docker-credential-ecr-login がインストールされていることを確認してください。")
                     }
 
-                    echo "ECRログイン成功: ${env.ECR_REGISTRY}"
+                    echo "ECR credential helper 検出済み（docker pull 時に自動認証されます）"
                 }
             }
         }


### PR DESCRIPTION
- Dockerfile: AWS CLI v2のインストールでuname -mによるアーキテクチャ判定を追加（ARM/x86_64）
- Jenkinsfile: ECR Loginをcredential helper検証に置き換え