### PR TITLE
fix: do not downgrade SDK stream error when result has is_error=true

### DIFF
--- a/src/core/claude-agent-client.ts
+++ b/src/core/claude-agent-client.ts
@@ -139,10 +139,11 @@ export class ClaudeAgentClient {
         const sanitizedMessage = sanitizeObjectStrings(message) as SDKMessage;
         messages.push(JSON.stringify(sanitizedMessage));
 
-        // type=result, subtype=success を受信した時点で本処理は完了している。
-        // この後に SDK が exit code 1 で落ちても本来の成果物には影響しない。
-        const m = message as { type?: string; subtype?: string };
-        if (m.type === 'result' && m.subtype === 'success') {
+        // type=result, subtype=success かつ is_error=false の場合のみ「真の成功」と判定する。
+        // Claude CLI は認証エラー(401)等でも subtype=success を返すケースがあるため、
+        // is_error フィールドで本当の成功/失敗を判別する必要がある。
+        const m = message as { type?: string; subtype?: string; is_error?: boolean };
+        if (m.type === 'result' && m.subtype === 'success' && m.is_error !== true) {
           sawSuccessResult = true;
         }
 

--- a/src/core/helpers/log-formatter.ts
+++ b/src/core/helpers/log-formatter.ts
@@ -176,9 +176,11 @@ export function formatClaudeLog(message: SDKMessage): string {
         num_turns?: number;
         duration_ms?: number;
         result?: string;
+        is_error?: boolean;
       };
+      const isErrorSuffix = resultMessage.is_error === true ? ', is_error=true' : '';
       logs.push(
-        `[AGENT RESULT] status=${resultMessage.subtype ?? 'success'}, turns=${resultMessage.num_turns ?? 'N/A'}, duration_ms=${resultMessage.duration_ms ?? 'N/A'}`,
+        `[AGENT RESULT] status=${resultMessage.subtype ?? 'success'}, turns=${resultMessage.num_turns ?? 'N/A'}, duration_ms=${resultMessage.duration_ms ?? 'N/A'}${isErrorSuffix}`,
       );
       if (typeof resultMessage.result === 'string' && resultMessage.result.trim().length > 0) {
         logs.push(`[AGENT RESULT] ${resultMessage.result}`);


### PR DESCRIPTION
Claude CLI は認証エラー(401)等の API エラー時にも `subtype: success` を返しており、 直前のコミットで導入した「success 受信後の stream エラーを warning に降格」ガードが 本来の認証失敗まで握り潰してしまっていた。

- ClaudeAgentClient.executeTask: success 判定に `is_error !== true` を追加し、 is_error=true の result は成功として扱わない（後続 stream エラーが致命のまま伝播）
- log-formatter: result メッセージのログに is_error=true を出力し、 認証失敗等の真の原因を識別可能にする